### PR TITLE
use kubectl_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Kuber = "87e52247-8a1b-5e01-9430-8fbcac83a23a"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 
 [compat]
 JSON = "0.21"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ This is a `ClusterManager` for usage from a driver julia session that:
 - is running on the cluster already.
 - has access to a working `kubectl` (from the julia-running-in-k8s-container context)
 
-You can easily set yourself up with just such a julia session. Assuming you have `kubectl` installed locally and configured to connect to a cluster in namespace "my-namespace", the following `driver.yaml` file containing a pod spec
+Assuming you have `kubectl` installed locally and configured to connect to a cluster in namespace "my-namespace",
+you can easily set yourself up with just such a julia session by running for example `kubectl run example-driver-pod -it --image julia:1.5.3 -n my-namespace`.
+
+Or equivlently, the following `driver.yaml` file containing a pod spec
 
 ```yaml
 apiVersion: v1
@@ -21,17 +24,13 @@ metadata:
     name: example-driver-pod
 spec:
     containers:
-        - name: kubectl-sidecar
-          image: bitnami/kubectl
-          command: ["kubectl"]
-          args: ["proxy", "--port=8001"]
         - name: driver
-          image: julia:1.5.2
+          image: julia:1.5.3
           stdin: true
           tty: true
 ```
 
-will get you a julia REPL running in the cluster alongside a `kubectl proxy` that it can talk to, by doing:
+will drop you into a julia REPL running in the cluster by doing:
 
 ```bash
 kubectl apply -f driver.yaml -n my-namespace
@@ -43,6 +42,8 @@ kubectl attach pod/example-driver-pod -c driver -it -n my-namespace
 Now in this julia REPL session, you can do:
 
 ```julia
+]add K8sClusterManagers
+
 using K8sClusterManagers
 
 pids = K8sClusterManagers.addprocs_pod(2; namespace="my-namespace")

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -15,10 +15,18 @@ export addprocs_pod
 export K8sNativeManager
 export launch, manage, kill
 
-function __init__()
+const kubectl_proxy_process = Ref{Base.Process}()
+
+function restart_kubectl_proxy()
+    port = get(ENV, "KUBECTL_PROXY_PORT", 8001)
+    if isassigned(kubectl_proxy_process)
+        kill(kubectl_proxy_process[])
+    end
     kubectl() do exe
-        run(`$exe proxy --port=8001`; wait=false)
+        kubectl_proxy_process[] = run(`$exe proxy --port=$port`; wait=false)
     end
 end
+
+__init__() = restart_kubectl_proxy()
 
 end

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -3,6 +3,7 @@ module K8sClusterManagers
 using Dates
 using Distributed
 using JSON
+using kubectl_jll
 using Kuber
 
 import Distributed: launch, manage, kill
@@ -13,5 +14,11 @@ include("native_driver.jl")
 export addprocs_pod
 export K8sNativeManager
 export launch, manage, kill
+
+function __init__()
+    kubectl() do exe
+        run(`$exe proxy --port=8001`; wait=false)
+    end
+end
 
 end


### PR DESCRIPTION
kubectl is no longer required to be running in a side-car container

addresses #6 

This ends up simplifying a couple of other annoyances:
- no need to pass in an `IMAGE` env variable; since there is only one container in the pod, we can default to using the driver container's image for workers by passing `image=nothing` to `addprocs_pod`.
- if the driver is running as a job, that job will complete on exit only if there are no side-cars.