### PR TITLE
Address reporting duplicate error messages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,8 @@ Kuber = "0.4.0"
 julia = "1.3"
 
 [extras]
+Swagger = "2d69052b-6a58-5cd9-a030-a48559c324ac"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Swagger", "Test"]

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -64,7 +64,11 @@ function default_pods_and_context(namespace="default"; configure, ports, driver_
     ctx = KuberContext()
     Kuber.set_api_versions!(ctx; verbose=false)
     set_ns(ctx, namespace)
-    pods = Dict(port => configure(default_pod(ctx, port, cmd, driver_name; kwargs...)) for port in ports)
+
+    # Avoid using a generator with `Dict` as any raised exception would be displayed twice:
+    # https://github.com/JuliaLang/julia/issues/33147
+    pods = Dict([port => configure(default_pod(ctx, port, cmd, driver_name; kwargs...)) for port in ports])
+
     return pods, ctx
 end
 

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -16,7 +16,12 @@ const empty_pod = """{
 Kuber object representing the pod this julia session is running in.
 """
 function self_pod(ctx)
-    return get(ctx, :Pod, ENV["HOSTNAME"])
+    # The following code is equivalent to calling Kuber's `get(ctx, :Pod, ENV["HOSTNAME"])`
+    # but reduces noise by avoiding nested rethrow calls.
+    # Fixed in Kuber.jl in: https://github.com/JuliaComputing/Kuber.jl/pull/26
+    isempty(ctx.apis) && Kuber.set_api_versions!(ctx)
+    api_ctx = Kuber._get_apictx(ctx, :Pod, nothing)
+    return Kuber.readNamespacedPod(api_ctx, ENV["HOSTNAME"], ctx.namespace)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,20 @@
-using Test
-using K8sClusterManagers
 using Distributed
+using K8sClusterManagers
+using Swagger
+using Test
 
+
+@testset "K8sClusterManagers" begin
+    @testset "addprocs_pod" begin
+        @testset "pods not found" begin
+            withenv("HOSTNAME" => "localhost") do
+                try
+                    K8sClusterManagers.addprocs_pod(1)
+                catch ex
+                    @test ex isa Swagger.ApiException
+                    @test length(Base.catch_stack()) == 2  # Ideally would be 1...
+                end
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,25 @@
 using Distributed
 using K8sClusterManagers
+using Kuber: KuberContext
 using Swagger
 using Test
 
 
 @testset "K8sClusterManagers" begin
+    @testset "self_pod" begin
+        @testset "non-nested exceptions" begin
+            ctx = KuberContext()
+            withenv("HOSTNAME" => "localhost") do
+                try
+                    K8sClusterManagers.self_pod(ctx)
+                catch ex
+                    @test ex isa Swagger.ApiException
+                    @test length(Base.catch_stack()) == 1
+                end
+            end
+        end
+    end
+
     @testset "addprocs_pod" begin
         @testset "pods not found" begin
             withenv("HOSTNAME" => "localhost") do
@@ -12,7 +27,7 @@ using Test
                     K8sClusterManagers.addprocs_pod(1)
                 catch ex
                     @test ex isa Swagger.ApiException
-                    @test length(Base.catch_stack()) == 2  # Ideally would be 1...
+                    @test length(Base.catch_stack()) == 1
                 end
             end
         end


### PR DESCRIPTION
Addresses part of this comment: https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/12#issuecomment-804397605

> Fix the double stack trace. I'm not sure why the stack trace was emitted twice here but it's also just adding noise

Here's a quick example when running the cluster manager on my local system. I've removed the stacktraces to make the output shorter.

Without this PR:
```julia
julia> ENV["HOSTNAME"] = "localhost";

julia> K8sClusterManagers.addprocs_pod(1)
[ Info: unsupported events.k8s.io/v1
[ Info: unsupported certificates.k8s.io/v1
[ Info: unsupported node.k8s.io/v1
[ Info: unsupported flowcontrol.apiserver.k8s.io/v1beta1
ERROR: Swagger.ApiException(404, "Not Found", HTTP.Messages.Response:
"""
HTTP/1.1 404 Not Found
Cache-Control: no-cache, private
Content-Length: 186
Content-Type: application/json
Date: Fri, 09 Apr 2021 17:55:56 GMT
X-Kubernetes-Pf-Flowschema-Uid: 198121e7-8b62-4f63-a220-9ebe10e3e597
X-Kubernetes-Pf-Prioritylevel-Uid: 03120ce8-c0ee-46e3-8213-e7f5473f6db0
Connection: close

{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"localhost\" not found","reason":"NotFound","details":{"name":"localhost","kind":"pods"},"code":404}
""")
Stacktrace: ...

caused by: UndefVarError: readPod not defined
Stacktrace: ...

caused by: Swagger.ApiException(404, "Not Found", HTTP.Messages.Response:
"""
HTTP/1.1 404 Not Found
Cache-Control: no-cache, private
Content-Length: 186
Content-Type: application/json
Date: Fri, 09 Apr 2021 17:55:56 GMT
X-Kubernetes-Pf-Flowschema-Uid: 198121e7-8b62-4f63-a220-9ebe10e3e597
X-Kubernetes-Pf-Prioritylevel-Uid: 03120ce8-c0ee-46e3-8213-e7f5473f6db0
Connection: close

{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"localhost\" not found","reason":"NotFound","details":{"name":"localhost","kind":"pods"},"code":404}
""")
Stacktrace: ...

caused by: UndefVarError: readPod not defined
Stacktrace: ...
```

With this PR:
```julia
julia> ENV["HOSTNAME"] = "localhost";

julia> K8sClusterManagers.addprocs_pod(1)
[ Info: unsupported events.k8s.io/v1
[ Info: unsupported certificates.k8s.io/v1
[ Info: unsupported node.k8s.io/v1
[ Info: unsupported flowcontrol.apiserver.k8s.io/v1beta1
ERROR: Swagger.ApiException(404, "Not Found", HTTP.Messages.Response:
"""
HTTP/1.1 404 Not Found
Cache-Control: no-cache, private
Content-Length: 186
Content-Type: application/json
Date: Fri, 09 Apr 2021 17:56:57 GMT
X-Kubernetes-Pf-Flowschema-Uid: 198121e7-8b62-4f63-a220-9ebe10e3e597
X-Kubernetes-Pf-Prioritylevel-Uid: 03120ce8-c0ee-46e3-8213-e7f5473f6db0
Connection: close

{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"localhost\" not found","reason":"NotFound","details":{"name":"localhost","kind":"pods"},"code":404}
""")
Stacktrace: ...

caused by: UndefVarError: readPod not defined
Stacktrace: ...
```