### PR TITLE
Define `current_namespace` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,4 +23,4 @@ Swagger = "2d69052b-6a58-5cd9-a030-a48559c324ac"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Suppressor", "Swagger", Test"]
+test = ["Suppressor", "Swagger", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,11 +14,13 @@ kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 [compat]
 JSON = "0.21"
 Kuber = "0.4.0"
+Suppressor = "0.2"
 julia = "1.3"
 
 [extras]
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Swagger = "2d69052b-6a58-5cd9-a030-a48559c324ac"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Swagger", "Test"]
+test = ["Suppressor", "Swagger", Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,11 @@ kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 [compat]
 JSON = "0.21"
 Kuber = "0.4.0"
-Suppressor = "0.2"
 julia = "1.3"
 
 [extras]
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Swagger = "2d69052b-6a58-5cd9-a030-a48559c324ac"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Suppressor", "Swagger", "Test"]
+test = ["Swagger", "Test"]

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -12,15 +12,15 @@ const empty_pod = """{
 
 
 """
-    default_namespace() -> String
+    current_namespace() -> String
 
-Determine the default Kubernetes namespace as specified by the current `kubectl` context.
-Typically, the default namespace is: "default".
+Determine the Kubernetes namespace as specified by the current context. Typically, the
+current namespace is: "default".
 
-If the namespace isn't set, the current context isn't set, or the current context isn't
+If the namespace is not set, the current context is not set, or the current context is not
 defined then an empty string will be returned.
 """
-function default_namespace()
+function current_namespace()
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
     # Equivalent to running `kubectl config view --minify --output='jsonpath={..namespace}'`
     # but improves handling of corner cases.
@@ -91,7 +91,7 @@ function default_pod(ctx, port, cmd::Cmd, driver_name::String; image=nothing, me
     return ko
 end
 
-function default_pods_and_context(namespace=default_namespace(); configure, ports, driver_name::String="driver", cmd::Cmd=`julia $(worker_arg())`, kwargs...)
+function default_pods_and_context(namespace=current_namespace(); configure, ports, driver_name::String="driver", cmd::Cmd=`julia $(worker_arg())`, kwargs...)
     ctx = KuberContext()
     Kuber.set_api_versions!(ctx; verbose=false)
     set_ns(ctx, namespace)
@@ -111,7 +111,7 @@ struct K8sNativeManager <: ClusterManager
                               driver_name::String,
                               cmd::Cmd;
                               configure=identity,
-                              namespace::String=default_namespace(),
+                              namespace::String=current_namespace(),
                               retry_seconds::Int,
                               kwargs...)
         pods, ctx = default_pods_and_context(namespace; configure=configure, driver_name=driver_name, ports=ports, cmd=cmd, kwargs...)
@@ -193,7 +193,7 @@ end
 """
     addprocs_pod(np::Int;
                  configure=identity,
-                 namespace::String=default_namespace(),
+                 namespace::String=current_namespace(),
                  image=nothing,
                  memory::String="4Gi",
                  cpu::String="1",
@@ -215,7 +215,7 @@ For more advanced configuration,
 function addprocs_pod(np::Int;
                       driver_name::String=get(ENV, "HOSTNAME", "localhost"),
                       configure=identity,
-                      namespace::String=default_namespace(),
+                      namespace::String=current_namespace(),
                       image=nothing,
                       serviceAccountName=nothing,
                       memory::String="4Gi",

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -12,20 +12,16 @@ const empty_pod = """{
 
 
 """
-    default_namespace() -> Union{String,Nothing}
+    default_namespace() -> String
 
 Determine the default Kubernetes namespace as specified by the current `kubectl` context.
-Typically, the default namespace is: "default". If no current context is set then `nothing`
-will be returned.
+Typically, the default namespace is: "default". If the current context isn't set or is does
+not exist then an exception will be thrown.
 """
 function default_namespace()
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
     kubectl() do exe
-        if !isempty(read(`$exe config view --output 'jsonpath={.current-context}'`, String))
-            read(`$exe config view --minify --output 'jsonpath={..namespace}'`, String)
-        else
-            nothing
-        end
+        read(`$exe config view --minify --output 'jsonpath={..namespace}'`, String)
     end
 end
 

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -22,10 +22,10 @@ defined then an empty string will be returned.
 """
 function default_namespace()
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-    # Equivalent to running `kubectl config view --minify ==output='jsonpath={..namespace}'`
+    # Equivalent to running `kubectl config view --minify --output='jsonpath={..namespace}'`
     # but improves handling of corner cases.
     kubectl() do exe
-        context = read(`$exe config view --output 'jsonpath={.current-context}'`, String)
+        context = read(`$exe config view --output='jsonpath={.current-context}'`, String)
         isempty(context) && return ""
 
         # Note: The output from `kubectl config view` reports a missing `namespace` entry,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,10 +7,10 @@ using kubectl_jll: kubectl
 
 
 @testset "K8sClusterManagers" begin
-    @testset "default_namespace" begin
+    @testset "current_namespace" begin
         @testset "user namespace" begin
-            # Validate that we can process whatever the system namespace is
-            result = @test K8sClusterManagers.default_namespace() isa String
+            # Validate that we can process whatever the current system's namespace is
+            result = @test K8sClusterManagers.current_namespace() isa String
 
             if !(result isa Test.Pass)
                 kubectl() do exe
@@ -36,7 +36,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.default_namespace() == "test-namespace"
+                @test K8sClusterManagers.current_namespace() == "test-namespace"
             end
         end
 
@@ -51,7 +51,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.default_namespace() == ""
+                @test K8sClusterManagers.current_namespace() == ""
             end
         end
 
@@ -70,7 +70,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.default_namespace() == ""
+                @test K8sClusterManagers.current_namespace() == ""
             end
         end
 
@@ -89,7 +89,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.default_namespace() == ""
+                @test K8sClusterManagers.current_namespace() == ""
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ using kubectl_jll: kubectl
             end
         end
 
+        # Note: Mirrors the config returned when running in the CI environment
         @testset "no current context" begin
             config_path = tempname()
             write(config_path,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Distributed
 using K8sClusterManagers
+using K8sClusterManagers: DEFAULT_NAMESPACE
 using Kuber: KuberContext
 using Swagger
 using Test
@@ -51,7 +52,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.current_namespace() == ""
+                @test K8sClusterManagers.current_namespace() == DEFAULT_NAMESPACE
             end
         end
 
@@ -70,7 +71,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.current_namespace() == ""
+                @test K8sClusterManagers.current_namespace() == DEFAULT_NAMESPACE
             end
         end
 
@@ -89,7 +90,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.current_namespace() == ""
+                @test K8sClusterManagers.current_namespace() == DEFAULT_NAMESPACE
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using Distributed
 using K8sClusterManagers
 using Kuber: KuberContext
-using Suppressor
 using Swagger
 using Test
 using kubectl_jll: kubectl
@@ -51,11 +50,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                err = @capture_err begin
-                    @test_throws ProcessFailedException K8sClusterManagers.default_namespace()
-                end
-
-                @test chomp(err) == "error: current-context must exist in order to minify"
+                @test K8sClusterManagers.default_namespace() == ""
             end
         end
 
@@ -93,11 +88,7 @@ using kubectl_jll: kubectl
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                err = @capture_err begin
-                    @test_throws ProcessFailedException K8sClusterManagers.default_namespace()
-                end
-
-                @test chomp(err) == "error: cannot locate context foo"
+                @test K8sClusterManagers.default_namespace() == ""
             end
         end
     end


### PR DESCRIPTION
I was just going to store `"default"` as a global constant but after reviewing https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ I opted for this solution