### PR TITLE
Validate kubectl_jll is available

### DIFF
--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -27,6 +27,13 @@ function restart_kubectl_proxy()
     end
 end
 
-__init__() = restart_kubectl_proxy()
+function __init__()
+    if !kubectl_jll.is_available()
+        error("kubectl_jll does not support the current platform. See: ",
+              "https://github.com/JuliaBinaryWrappers/kubectl_jll.jl#platforms")
+    end
+
+    restart_kubectl_proxy()
+end
 
 end


### PR DESCRIPTION
Without this check non supported platforms (like Apple Silicon) fail in a non-obvious way:
```julia
julia> using K8sClusterManagers
[ Info: Precompiling K8sClusterManagers [5aeab163-63d2-4171-9fbf-e22244d80acb]
ERROR: InitError: UndefVarError: kubectl not defined
during initialization of module K8sClusterManagers
```