### PR TITLE
Add comments for `restart_kubectl_proxy`

### DIFF
--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -19,7 +19,8 @@ const kubectl_proxy_process = Ref{Base.Process}()
 
 function restart_kubectl_proxy()
     # Note: "KUBECTL_PROXY_PORT" is a made up environmental variable and is not supported by
-    # `kubectl proxy`.
+    # `kubectl proxy`. The default port (8001) is what `kubectl proxy` uses when `--port` is
+    # not specified.
     port = get(ENV, "KUBECTL_PROXY_PORT", 8001)
     if isassigned(kubectl_proxy_process)
         kill(kubectl_proxy_process[])

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -35,6 +35,7 @@ function __init__()
               "https://github.com/JuliaBinaryWrappers/kubectl_jll.jl#platforms")
     end
 
+    # Kuber.jl expects that Kubernetes API server is available via: http://localhost:8001
     restart_kubectl_proxy()
 end
 

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -18,6 +18,8 @@ export launch, manage, kill
 const kubectl_proxy_process = Ref{Base.Process}()
 
 function restart_kubectl_proxy()
+    # Note: "KUBECTL_PROXY_PORT" is a made up environmental variable and is not supported by
+    # `kubectl proxy`.
     port = get(ENV, "KUBECTL_PROXY_PORT", 8001)
     if isassigned(kubectl_proxy_process)
         kill(kubectl_proxy_process[])


### PR DESCRIPTION
As `kubectl` itself doesn't require this proxy to the Kubernetes API server I experimented with removing the proxy entirely and discovered:
```juia
julia> K8sClusterManagers.addprocs_pod(3)
ERROR: IOError(Base.IOError("connect: connection refused (ECONNREFUSED)", -111) during request(http://localhost:8001/api/))

Stacktrace:
 [1] wait_connected(::Sockets.TCPSocket) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Sockets/src/Sockets.jl:525
 [2] connect at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Sockets/src/Sockets.jl:560 [inlined]
 [3] connect(::Sockets.IPv4, ::UInt64) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Sockets/src/Sockets.jl:546
 [4] getconnection(::Type{Sockets.TCPSocket}, ::SubString{String}, ::SubString{String}; keepalive::Bool, connect_timeout::Int64, kw::Base.Iterators.Pairs{Symbol,Any,NTuple{5,Symbol},NamedTuple{(:require_ssl_verification, :iofunction, :reached_redirect_limit, :status_exception, :readtimeout),Tuple{Bool,Nothing,Bool,Bool,Int64}}}) at /root/.julia/packages/HTTP/IAI92/src/ConnectionPool.jl:630
 [5] #newconnection#25 at /root/.julia/packages/HTTP/IAI92/src/ConnectionPool.jl:597 [inlined]
 [6] getconnection(::Type{HTTP.ConnectionPool.Transaction{Sockets.TCPSocket}}, ::SubString{String}, ::SubString{String}; connection_limit::Int64, pipeline_limit::Int64, idle_timeout::Int64, reuse_limit::Int64, require_ssl_verification::Bool, kw::Base.Iterators.Pairs{Symbol,Any,NTuple{4,Symbol},NamedTuple{(:iofunction, :reached_redirect_limit, :status_exception, :readtimeout),Tuple{Nothing,Bool,Bool,Int64}}}) at /root/.julia/packages/HTTP/IAI92/src/ConnectionPool.jl:541
 [7] request(::Type{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.TimeoutRequest.TimeoutLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}, ::HTTP.URIs.URI, ::HTTP.Messages.Request, ::Array{UInt8,1}; proxy::Nothing, socket_type::Type{T} where T, reuse_limit::Int64, kw::Base.Iterators.Pairs{Symbol,Any,NTuple{5,Symbol},NamedTuple{(:iofunction, :reached_redirect_limit, :require_ssl_verification, :status_exception, :readtimeout),Tuple{Nothing,Bool,Bool,Bool,Int64}}}) at /root/.julia/packages/HTTP/IAI92/src/ConnectionRequest.jl:73
 [8] (::Base.var"#56#58"{Base.var"#56#57#59"{ExponentialBackOff,HTTP.RetryRequest.var"#2#3"{Bool,HTTP.Messages.Request},typeof(HTTP.request)}})(::Type{T} where T, ::Vararg{Any,N} where N; kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{5,Symbol},NamedTuple{(:iofunction, :reached_redirect_limit, :require_ssl_verification, :status_exception, :readtimeout),Tuple{Nothing,Bool,Bool,Bool,Int64}}}) at ./error.jl:301
 [9] #request#1 at /root/.julia/packages/HTTP/IAI92/src/RetryRequest.jl:44 [inlined]
 [10] request(::Type{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.TimeoutRequest.TimeoutLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Array{UInt8,1}; http_version::VersionNumber, target::String, parent::Nothing, iofunction::Nothing, kw::Base.Iterators.Pairs{Symbol,Integer,NTuple{5,Symbol},NamedTuple{(:reached_redirect_limit, :require_ssl_verification, :retries, :status_exception, :readtimeout),Tuple{Bool,Bool,Int64,Bool,Int64}}}) at /root/.julia/packages/HTTP/IAI92/src/MessageRequest.jl:51
 [11] request(::Type{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.TimeoutRequest.TimeoutLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Array{UInt8,1}; kw::Base.Iterators.Pairs{Symbol,Integer,NTuple{5,Symbol},NamedTuple{(:reached_redirect_limit, :require_ssl_verification, :retries, :status_exception, :readtimeout),Tuple{Bool,Bool,Int64,Bool,Int64}}}) at /root/.julia/packages/HTTP/IAI92/src/BasicAuthRequest.jl:28
 [12] request(::Type{HTTP.RedirectRequest.RedirectLayer{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.RetryRequest.RetryLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.TimeoutRequest.TimeoutLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}}}, ::String, ::HTTP.URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::Array{UInt8,1}; redirect_limit::Int64, forwardheaders::Bool, kw::Base.Iterators.Pairs{Symbol,Integer,NTuple{4,Symbol},NamedTuple{(:require_ssl_verification, :retries, :status_exception, :readtimeout),Tuple{Bool,Int64,Bool,Int64}}}) at /root/.julia/packages/HTTP/IAI92/src/RedirectRequest.jl:24
 [13] request(::String, ::HTTP.URIs.URI, ::Dict{String,String}, ::Array{UInt8,1}; headers::Dict{String,String}, body::Array{UInt8,1}, query::Nothing, kw::Base.Iterators.Pairs{Symbol,Integer,NTuple{4,Symbol},NamedTuple{(:require_ssl_verification, :retries, :status_exception, :readtimeout),Tuple{Bool,Int64,Bool,Int64}}}) at /root/.julia/packages/HTTP/IAI92/src/HTTP.jl:314
 [14] exec(::Swagger.Ctx) at /root/.julia/packages/Swagger/4eKnR/src/client.jl:211
 [15] getCoreAPIVersions(::Kuber.Kubernetes.CoreApi; _mediaType::Nothing) at /root/.julia/packages/Kuber/UfXri/src/api/api_CoreApi.jl:17
 [16] getCoreAPIVersions at /root/.julia/packages/Kuber/UfXri/src/api/api_CoreApi.jl:14 [inlined]
 [17] macro expansion at /root/.julia/packages/Retry/vS1bg/src/repeat_try.jl:192 [inlined]
 [18] fetch_core_version(::Kuber.KuberContext; override::Nothing, verbose::Bool, max_tries::Int64) at /root/.julia/packages/Kuber/UfXri/src/helpers.jl:162
 [19] set_api_versions!(::Kuber.KuberContext; override::Nothing, verbose::Bool, max_tries::Int64) at /root/.julia/packages/Kuber/UfXri/src/helpers.jl:220
 [20] default_pods_and_context(::String; configure::typeof(identity), ports::UnitRange{Int64}, driver_name::String, cmd::Cmd, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{4,Symbol},NamedTuple{(:image, :memory, :cpu, :serviceAccountName),Tuple{Nothing,String,String,Nothing}}}) at /root/.julia/packages/K8sClusterManagers/IBv9R/src/native_driver.jl:97
 [21] K8sNativeManager(::UnitRange{Int64}, ::String, ::Cmd; configure::Function, namespace::String, retry_seconds::Int64, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{4,Symbol},NamedTuple{(:image, :memory, :cpu, :serviceAccountName),Tuple{Nothing,String,String,Nothing}}}) at /root/.julia/packages/K8sClusterManagers/IBv9R/src/native_driver.jl:118
 [22] addprocs_pod(::Int64; driver_name::String, configure::Function, namespace::String, image::Nothing, serviceAccountName::Nothing, memory::String, cpu::String, retry_seconds::Int64, exename::Cmd, exeflags::Cmd, params::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /root/.julia/packages/K8sClusterManagers/IBv9R/src/native_driver.jl:229
 [23] addprocs_pod(::Int64) at /root/.julia/packages/K8sClusterManagers/IBv9R/src/native_driver.jl:228
 [24] top-level scope at REPL[5]:1
```
From looking at the stack trace you can see that Kuber.jl requires access. I'll document this requirement for now and hopefully we can either move away from Kuber.jl or separate this requirement from K8sClusterManagers.jl