### PR TITLE
Determine namespace inside of pod

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,14 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Kuber = "87e52247-8a1b-5e01-9430-8fbcac83a23a"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 
 [compat]
 JSON = "0.21"
 Kuber = "0.4.0"
+Mocking = "0.7"
 Mustache = "1"
 julia = "1.3"
 

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -5,6 +5,7 @@ using Distributed
 using JSON
 using kubectl_jll
 using Kuber
+using Mocking: Mocking, @mock
 
 import Distributed: launch, manage, kill
 

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -11,17 +11,23 @@ const empty_pod = """{
 }"""
 
 const DEFAULT_NAMESPACE = "default"
+const NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 """
     current_namespace() -> String
 
-Determine the Kubernetes namespace as specified by the current context. If the namespace is
-not set, the current context is not set, or the current context is not defined then the
-default namespace ("$DEFAULT_NAMESPACE") will be returned.
+Determine the Kubernetes namespace usually specified by the current context. When running
+inside of a Kubernetes pod the namespace of the pod will be returned.
+
+If the namespace is not set, the current context is not set, or the current context is not
+defined then the default namespace ("$DEFAULT_NAMESPACE") will be returned.
 """
 function current_namespace()
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-    #
+
+    # When running inside of a pod use the current pod's namespace
+    @mock(isfile(NAMESPACE_FILE)) && return @mock(read(NAMESPACE_FILE, String))
+
     # Equivalent to running `kubectl config view --minify --output='jsonpath={..namespace}'`
     # but improves handling of corner cases.
     kubectl() do exe

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -19,7 +19,7 @@ const NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 Determine the Kubernetes namespace as specified by the current config context. If the
 namespace is not set, the current context is not set, or the current context is not defined
-then the default namespace `nothing` will be returned.
+then `nothing` will be returned.
 """
 function config_namespace()
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
@@ -42,7 +42,8 @@ end
 """
     pod_namespace() -> Union{String,Nothing}
 
-Return the namespace of the pod if running inside of a Kubernetes pod, otherwise `nothing`.
+Determine the namespace of the pod if running inside of a Kubernetes pod, otherwise return
+`nothing`.
 """
 function pod_namespace()
     return if @mock isfile(NAMESPACE_FILE)

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -15,13 +15,13 @@ const NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 
 """
-    current_config_namespace() -> Union{String,Nothing}
+    config_namespace() -> Union{String,Nothing}
 
 Determine the Kubernetes namespace as specified by the current config context. If the
 namespace is not set, the current context is not set, or the current context is not defined
 then the default namespace `nothing` will be returned.
 """
-function current_config_namespace()
+function config_namespace()
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
     #
     # Equivalent to running `kubectl config view --minify --output='jsonpath={..namespace}'`
@@ -56,12 +56,12 @@ end
 """
     current_namespace() -> String
 
-Determine the Kubernetes namespace as specified by the config or, when running inside a pod,
-the namespace of the pod. If the namespace is cannot be determined the default namespace
-("$DEFAULT_NAMESPACE") will be returned.
+Determine the Kubernetes namespace as specified by the current config or, when running
+inside a pod, the namespace of the pod. If the namespace is cannot be determined the default
+namespace ("$DEFAULT_NAMESPACE") will be returned.
 """
 function current_namespace()
-    namespace = current_config_namespace()
+    namespace = config_namespace()
     namespace !== nothing && return namespace
 
     namespace = pod_namespace()

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -13,33 +13,61 @@ const empty_pod = """{
 const DEFAULT_NAMESPACE = "default"
 const NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
-"""
-    current_namespace() -> String
 
-Determine the Kubernetes namespace usually specified by the current context. When running
-inside of a Kubernetes pod the namespace of the pod will be returned.
-
-If the namespace is not set, the current context is not set, or the current context is not
-defined then the default namespace ("$DEFAULT_NAMESPACE") will be returned.
 """
-function current_namespace()
+    current_config_namespace() -> Union{String,Nothing}
+
+Determine the Kubernetes namespace as specified by the current config context. If the
+namespace is not set, the current context is not set, or the current context is not defined
+then the default namespace `nothing` will be returned.
+"""
+function current_config_namespace()
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-
-    # When running inside of a pod use the current pod's namespace
-    @mock(isfile(NAMESPACE_FILE)) && return @mock(read(NAMESPACE_FILE, String))
-
+    #
     # Equivalent to running `kubectl config view --minify --output='jsonpath={..namespace}'`
     # but improves handling of corner cases.
     kubectl() do exe
         context = read(`$exe config view --output='jsonpath={.current-context}'`, String)
-        isempty(context) && return DEFAULT_NAMESPACE
+        isempty(context) && return nothing
 
         # Note: The output from `kubectl config view` reports a missing `namespace` entry,
         # `namespace: null`, and `namespace: ""` as the same.
         output = "jsonpath={.contexts[?(@.name=='$context')].context.namespace}"
         namespace = read(`$exe config view --output=$output`, String)
-        return isempty(namespace) ? DEFAULT_NAMESPACE : namespace
+        return !isempty(namespace) ? namespace : nothing
     end
+end
+
+
+"""
+    pod_namespace() -> Union{String,Nothing}
+
+Return the namespace of the pod if running inside of a Kubernetes pod, otherwise `nothing`.
+"""
+function pod_namespace()
+    return if @mock isfile(NAMESPACE_FILE)
+        @mock read(NAMESPACE_FILE, String)
+    else
+        nothing
+    end
+end
+
+
+"""
+    current_namespace() -> String
+
+Determine the Kubernetes namespace as specified by the config or, when running inside a pod,
+the namespace of the pod. If the namespace is cannot be determined the default namespace
+("$DEFAULT_NAMESPACE") will be returned.
+"""
+function current_namespace()
+    namespace = current_config_namespace()
+    namespace !== nothing && return namespace
+
+    namespace = pod_namespace()
+    namespace !== nothing && return namespace
+
+    return DEFAULT_NAMESPACE
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,10 +13,10 @@ Mocking.activate()
 
 
 @testset "K8sClusterManagers" begin
-    @testset "current_config_namespace" begin
+    @testset "config_namespace" begin
         @testset "user namespace" begin
             # Validate that we can process whatever the current system's namespace is
-            result = @test K8sClusterManagers.current_config_namespace() isa Union{String,Nothing}
+            result = @test K8sClusterManagers.config_namespace() isa Union{String,Nothing}
 
             if !(result isa Test.Pass)
                 kubectl() do exe
@@ -42,7 +42,7 @@ Mocking.activate()
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.current_config_namespace() == "test-namespace"
+                @test K8sClusterManagers.config_namespace() == "test-namespace"
             end
         end
 
@@ -57,7 +57,7 @@ Mocking.activate()
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.current_config_namespace() === nothing
+                @test K8sClusterManagers.config_namespace() === nothing
             end
         end
 
@@ -76,7 +76,7 @@ Mocking.activate()
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.current_config_namespace() == nothing
+                @test K8sClusterManagers.config_namespace() == nothing
             end
         end
 
@@ -95,7 +95,7 @@ Mocking.activate()
                   """)
 
             withenv("KUBECONFIG" => config_path) do
-                @test K8sClusterManagers.current_config_namespace() == nothing
+                @test K8sClusterManagers.config_namespace() == nothing
             end
         end
     end
@@ -121,12 +121,12 @@ Mocking.activate()
 
     @testset "current_namespace" begin
         @testset "fallback namespace" begin
-            config_path = tempname()
+            config_path = touch(tempname())
             patches = [@patch isfile(f) = false]
 
             withenv("KUBECONFIG" => config_path) do
                 apply(patches) do
-                    @test K8sClusterManagers.pod_namespace() === nothing
+                    @test K8sClusterManagers.current_namespace() === DEFAULT_NAMESPACE
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,15 @@
 using Distributed
 using K8sClusterManagers
-using K8sClusterManagers: DEFAULT_NAMESPACE
+using K8sClusterManagers: DEFAULT_NAMESPACE, NAMESPACE_FILE
 using Kuber: KuberContext
 using LibGit2: LibGit2
+using Mocking: Mocking, @patch, apply
 using Mustache: Mustache, render
 using Swagger: Swagger
 using Test
 using kubectl_jll: kubectl
+
+Mocking.activate()
 
 
 @testset "K8sClusterManagers" begin
@@ -93,6 +96,15 @@ using kubectl_jll: kubectl
 
             withenv("KUBECONFIG" => config_path) do
                 @test K8sClusterManagers.current_namespace() == DEFAULT_NAMESPACE
+            end
+        end
+
+        @testset "namespace file" begin
+            patches = [@patch isfile(f) = f == NAMESPACE_FILE
+                       @patch read(f, ::Type{String}) = "pod-namespace"]
+
+            apply(patches) do
+                @test K8sClusterManagers.current_namespace() == "pod-namespace"
             end
         end
     end


### PR DESCRIPTION
I discovered when reading https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/#without-using-a-proxy that the service account directory inside a pod contains a "namespace" file containing the name of the pod's namespace. This PR means that K8sClusterManagers.jl users no longer need to specify the namespace when running inside of a pod which avoids mistakes which can lead to: https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/12