### PR TITLE
Revise to be inline with Cluster Manager interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # K8sClusterManagers.jl
 
 [![CI](https://github.com/beacon-biosignals/K8sClusterManagers.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/beacon-biosignals/K8sClusterManagers.jl/actions/workflows/CI.yml)
-[![codecov](https://codecov.io/gh/beacon-biosignals/Onda.jl/branch/master/graph/badge.svg?token=D0bcI0Rtsw)](https://codecov.io/gh/beacon-biosignals/Onda.jl)
+[![codecov](https://codecov.io/gh/beacon-biosignals/K8sClusterManagers.jl/branch/master/graph/badge.svg?token=MG8ZO4APDI)](https://codecov.io/gh/beacon-biosignals/K8sClusterManagers.jl)
 [![Docs: stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://beacon-biosignals.github.io/K8sClusterManagers.jl/stable)
 [![Docs: development](https://img.shields.io/badge/docs-dev-blue.svg)](https://beacon-biosignals.github.io/K8sClusterManagers.jl/dev)
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,71 @@
-# K8sClusterManagers
+# K8sClusterManagers.jl
 
 [![CI](https://github.com/beacon-biosignals/K8sClusterManagers.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/beacon-biosignals/K8sClusterManagers.jl/actions/workflows/CI.yml)
+[![codecov](https://codecov.io/gh/beacon-biosignals/Onda.jl/branch/master/graph/badge.svg?token=D0bcI0Rtsw)](https://codecov.io/gh/beacon-biosignals/Onda.jl)
 [![Docs: stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://beacon-biosignals.github.io/K8sClusterManagers.jl/stable)
 [![Docs: development](https://img.shields.io/badge/docs-dev-blue.svg)](https://beacon-biosignals.github.io/K8sClusterManagers.jl/dev)
 
-This repo contains a cluster manager for provisioning julia workers on a k8s cluster, making minimal assumptions about your cluster setup.
+A Julia cluster manager for provisioning workers in a Kubernetes (k8s) cluster.
 
-## K8sNativeManager
+## K8sClusterManager
 
-This is a `ClusterManager` for usage from a driver julia session that:
+This is a `ClusterManager` for usage from a driver Julia session that:
 - is running on the cluster already.
 - has access to a working `kubectl` (from the julia-running-in-k8s-container context)
 
 Assuming you have `kubectl` installed locally and configured to connect to a cluster in namespace "my-namespace",
 you can easily set yourself up with just such a julia session by running for example `kubectl run example-driver-pod -it --image julia:1.5.3 -n my-namespace`.
 
-Or equivlently, the following `driver.yaml` file containing a pod spec
+Or equivalently, the following `driver.yaml` file containing a pod spec
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-    name: example-driver-pod
+  name: example-driver-pod
 spec:
-    containers:
-        - name: driver
-          image: julia:1.5.3
-          stdin: true
-          tty: true
+  containers:
+    - name: driver
+      image: julia:1.5.3
+      stdin: true
+      tty: true
 ```
 
-will drop you into a julia REPL running in the cluster by doing:
+Running the following will drop you into a Julia REPL running Kubernetes pod:
 
-```bash
-kubectl apply -f driver.yaml -n my-namespace
+```sh
+kubectl apply -f driver.yaml
 
-#and once the pod is running
-kubectl attach pod/example-driver-pod -c driver -it -n my-namespace
+# Once the pod is running
+kubectl attach -it pod/example-driver-pod -c driver
 ```
 
-Now in this julia REPL session, you can do:
+Now in this Julia REPL session, you can do:
 
 ```julia
-]add K8sClusterManagers
+julia> using Pkg; Pkg.add("K8sClusterManagers")
 
-using K8sClusterManagers
+julia> using K8sClusterManagers
 
-pids = K8sClusterManagers.addprocs_pod(2; namespace="my-namespace")
+julia> addprocs(K8sClusterManager(2))
 ```
 
-#### advanced configuration
+### Advanced configuration
 
-`K8sClusterManagers.addprocs_pod` exposes a `configure` kwarg that can be used to make arbitrary modifications to the pod spec defining workers, which defaults to the identity function.
+`K8sClusterManager` exposes a `configure` keyword argument that can be used to make
+modifications to the pod spec defining workers.
 
-`configure(pod)` will be called on a `Kuber.jl` object `pod` representing a pod spec, and it must return an object of the same type. `Kuber.jl` makes it convenient to manipulate this `pod`, by letting you do things such as:
+When launching the cluster the function `configure(pod)` will be called where `pod` is a
+`Kuber.jl` object representing a pod spec. The function must return an object of the same
+type. `Kuber.jl` makes it convenient to manipulate this `pod`, by letting you do things such
+as:
 
 ```julia
 function my_configurator(pod)
-    push!(pod.spec.tolerations, """
-        {
-            "key": "gpu",
-            "operator": "Equal",
-            "value": "true"
-        }
-    """)
+    push!(pod.spec.tolerations,
+          Dict("key" => "gpu",
+               "operator" => "Equal",
+               "value" => "true"))
     return pod
 end
 ```
@@ -71,46 +73,45 @@ end
 To get an example instance of `pod` that might be passed into the `configure`, call
 
 ```julia
-pod, ctx = K8sClusterManagers.default_pod_and_context("my-namespace")
+using K8sClusterManagers, Kuber
+pod = K8sClusterManagers.worker_pod_spec(KuberContext(), port=0, cmd=`julia`, driver_name="driver", image="julia")
 ```
 
 
-## useful commands
+## Useful Commands
 
 Monitor the status of all your pods
-```bash
-watch -n 1 kubectl get pods,services -n my-namespace'
+```sh
+watch kubectl get pods,services
 ```
 
-tail the stdout of workers `example-driver-pod`
-```bash
-kubectl logs -f pod/example-driver-pod -c example-driver-pod-worker-9001 -n my-namespace
+Stream the stdout of the worker "example-driver-pod-worker-9001":
+```sh
+kubectl logs -f pod/example-driver-pod-worker-9001
 ```
 
-Currently cleaning up after / killing all your pods can be slow / ineffective from a julia context, especially if the driver julia session dies unexpectedly. It may be necessary to kill your workers from the command line.
-```bash
-kubectl delete pod/example-driver-pod-worker-9001 -n my-namespace --grace-period=0 --force=true
+Currently cleaning up after / killing all your pods can be slow / ineffective from a Julia
+context, especially if the driver Julia session dies unexpectedly. It may be necessary to
+kill your workers from the command line.
+```sh
+kubectl delete pod/example-driver-pod-worker-9001 --grace-period=0 --force=true
 ```
-It may be convenient to set a common label in your worker podspecs, so that you can select them all with `-l='...'` by label, and kill all the worker pods in one invocation.
-
+It may be convenient to set a common label in your worker podspecs, so that you can select them all with `-l='...'` by label, and kill all the worker pods in a single invocation.
 
 Display info about a pod -- this is especially useful to troubleshoot a pod that is taking longer than expected to get up and running.
-```bash
-kubectl describe pod/example-driver-pod -n my-namespace
+```sh
+kubectl describe pod/example-driver-pod
 ```
 
-## troubleshooting
+## Troubleshooting
 
 If you get `deserialize` errors during interations between driver and worker processes, make sure you are using the same version of Julia on the driver as on all the workers!
 
 If you aren't sure what went wrong, check the logs! The syntax is
 ```bash
-kubectl logs -f -n my-namespace pod_name -c container_name
+kubectl logs -f pod/pod_name
 ```
-where the pod name `pod_name` you can get from `kubectl get pods -n my-namespace` and `container_name` from 
-```bash
-kubectl describe pod pod_name -n my-namespace
-```
+where the pod name `pod_name` you can get from `kubectl get pods`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This is a `ClusterManager` for usage from a driver Julia session that:
 - is running on the cluster already.
 - has access to a working `kubectl` (from the julia-running-in-k8s-container context)
 
-Assuming you have `kubectl` installed locally and configured to connect to a cluster in namespace "my-namespace",
-you can easily set yourself up with just such a julia session by running for example `kubectl run example-driver-pod -it --image julia:1.5.3 -n my-namespace`.
+Assuming you have `kubectl` installed locally and configured to connect to a cluster using
+the namespace of your choice, you can easily set yourself up with just such a julia session
+by running for example `kubectl run example-driver-pod -it --image julia:1.5.3`.
 
 Or equivalently, the following `driver.yaml` file containing a pod spec
 
@@ -96,16 +97,19 @@ kill your workers from the command line.
 ```sh
 kubectl delete pod/example-driver-pod-worker-9001 --grace-period=0 --force=true
 ```
-It may be convenient to set a common label in your worker podspecs, so that you can select them all with `-l='...'` by label, and kill all the worker pods in a single invocation.
+It may be convenient to set a common label in your worker podspecs, so that you can select
+them all with `-l='...'` by label, and kill all the worker pods in a single invocation.
 
-Display info about a pod -- this is especially useful to troubleshoot a pod that is taking longer than expected to get up and running.
+Display info about a pod -- this is especially useful to troubleshoot a pod that is taking
+longer than expected to get up and running.
 ```sh
 kubectl describe pod/example-driver-pod
 ```
 
 ## Troubleshooting
 
-If you get `deserialize` errors during interations between driver and worker processes, make sure you are using the same version of Julia on the driver as on all the workers!
+If you get `deserialize` errors during interations between driver and worker processes, make
+sure you are using the same version of Julia on the driver as on all the workers!
 
 If you aren't sure what went wrong, check the logs! The syntax is
 ```bash
@@ -125,5 +129,6 @@ run with [minikube](https://minikube.sigs.k8s.io/).
 2. If using Docker Desktop: set the resources to a minimum of 3 CPUs and 2.25 GB Memory
 3. [Install minikube](https://minikube.sigs.k8s.io/docs/start/)
 4. Start the Kubernetes cluster: `minikube start`
-5. Use the in-cluster Docker daemon for image builds: `eval $(minikube docker-env)` (Note: only works with single-node clusters)
+5. Use the in-cluster Docker daemon for image builds: `eval $(minikube docker-env)`
+   (Note: only works with single-node clusters)
 6. Run the K8sClusterManagers.jl tests

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -6,11 +6,8 @@ using Kuber
 using Mocking: Mocking, @mock
 using kubectl_jll
 
-worker_arg() = `--worker=$(Distributed.init_multi(); cluster_cookie())`
-
-
-export addprocs_pod
 export K8sClusterManager
+
 
 const KUBECTL_PROXY_PROCESS = Ref{Base.Process}()
 

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -1,19 +1,16 @@
 module K8sClusterManagers
 
-using Distributed
+using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie
 using JSON
 using Kuber
 using Mocking: Mocking, @mock
 using kubectl_jll
 
-import Distributed: launch, manage, kill
-
 worker_arg() = `--worker=$(Distributed.init_multi(); cluster_cookie())`
 
 
 export addprocs_pod
-export K8sNativeManager
-export launch, manage, kill
+export K8sClusterManager
 
 const KUBECTL_PROXY_PROCESS = Ref{Base.Process}()
 

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -110,7 +110,7 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
     exename = params[:exename]
     exeflags = params[:exeflags]
 
-    cmd = `$exename $exeflags $(worker_arg())`
+    cmd = `$exename $exeflags --worker=$(cluster_cookie())`
 
     errors = Dict()
     # try not to overwhelm kubectl proxy; wait longer if more workers requested

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -49,7 +49,7 @@ function K8sClusterManager(np::Integer;
                            memory=DEFAULT_WORKER_MEMORY,
                            retry_seconds::Int=180,
                            configure=identity,
-                           _ctx=kuber_context(namespace))
+                           _ctx=_KuberContext(namespace))
 
     # Default to using the image of the pod if possible
     if image === nothing

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -117,9 +117,9 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
     sleeptime = 0.1 * sqrt(length(manager.ports))
     asyncmap(manager.ports) do port
         pod = @static if VERSION >= v"1.5"
-            worker_pod_spec(manager; port=port, cmd=cmd)
-        else
             worker_pod_spec(manager; port, cmd)
+        else
+            worker_pod_spec(manager; port=port, cmd=cmd)
         end
 
         pod = manager.configure(pod)

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -116,7 +116,13 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
     # try not to overwhelm kubectl proxy; wait longer if more workers requested
     sleeptime = 0.1 * sqrt(length(manager.ports))
     asyncmap(manager.ports) do port
-        pod = manager.configure(worker_pod_spec(manager; port, cmd))
+        pod = @static if VERSION >= v"1.5"
+            worker_pod_spec(manager; port=port, cmd=cmd)
+        else
+            worker_pod_spec(manager; port, cmd)
+        end
+
+        pod = manager.configure(pod)
 
         start = time()
         try

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -7,9 +7,14 @@ const EMPTY_POD =
                              "affinity" => Dict())))
 
 
-function kuber_context(namespace)
+function _KuberContext(namespace="default")
     ctx = KuberContext()
     set_ns(ctx, namespace)
+    return ctx
+end
+
+function _set_api_versions!(ctx::KuberContext)
+    isempty(ctx.apis) && Kuber.set_api_versions!(ctx)
     return ctx
 end
 
@@ -41,10 +46,10 @@ function worker_pod_spec(ctx;
                          cmd::Cmd,
                          driver_name::String,
                          image::String,
-                         cpu::String=DEFAULT_WORKER_CPU,
-                         memory::String=DEFAULT_WORKER_MEMORY,
+                         cpu=DEFAULT_WORKER_CPU,
+                         memory=DEFAULT_WORKER_MEMORY,
                          service_account_name=nothing,
-                         base_obj=kuber_obj(ctx, EMPTY_POD))
+                         base_obj=kuber_obj(_set_api_versions!(ctx), EMPTY_POD))
     ko = base_obj
     ko.metadata.name = "$(driver_name)-worker-$port"
     cmdo = `$cmd --bind-to=0:$port`

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -7,7 +7,7 @@ const EMPTY_POD =
                              "affinity" => Dict())))
 
 
-function _KuberContext(namespace="default")
+function _KuberContext(namespace=DEFAULT_NAMESPACE)
     ctx = KuberContext()
     set_ns(ctx, namespace)
     return ctx

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -6,39 +6,49 @@ const EMPTY_POD =
                              "containers" => [],
                              "affinity" => Dict())))
 
+
+function kuber_context(namespace=current_namespace())
+    ctx = KuberContext()
+    Kuber.set_api_versions!(ctx; verbose=false)
+    set_ns(ctx, namespace)
+    return ctx
+end
+
 """
     self_pod(ctx::KuberContext)
 
 Kuber object representing the pod this julia session is running in.
 """
-function self_pod(ctx)
+self_pod(ctx) = get_pod(ctx, ENV["HOSTNAME"])
+
+
+function get_pod(ctx, pod_name)
     # The following code is equivalent to calling Kuber's `get(ctx, :Pod, ENV["HOSTNAME"])`
     # but reduces noise by avoiding nested rethrow calls.
     # Fixed in Kuber.jl in: https://github.com/JuliaComputing/Kuber.jl/pull/26
     isempty(ctx.apis) && Kuber.set_api_versions!(ctx)
     api_ctx = Kuber._get_apictx(ctx, :Pod, nothing)
-    return Kuber.readNamespacedPod(api_ctx, ENV["HOSTNAME"], ctx.namespace)
+    return Kuber.readNamespacedPod(api_ctx, pod_name, ctx.namespace)
 end
 
 
 """
-    default_pod(ctx, port, cmd::Cmd, driver_name::String; image=nothing, memory::String="4Gi", cpu::String="1", base_obj=kuber_obj(ctx, EMPTY_POD))
+    worker_pod_spec(ctx; kwargs...)
 
-Kuber object representing a pod with a single worker container.
-
-If `isnothing(image) == true`, the driver pod is required to have a single container, whose image will be used.
+Generate a Kuber object representing pod with a single worker container.
 """
-function default_pod(ctx, port, cmd::Cmd, driver_name::String; image=nothing, memory::String="4Gi", cpu::String="1", serviceAccountName=nothing, base_obj=kuber_obj(ctx, EMPTY_POD), kwargs...)
+function worker_pod_spec(ctx;
+                         port::Integer,
+                         cmd::Cmd,
+                         driver_name::String,
+                         image::String,
+                         cpu::String=DEFAULT_WORKER_CPU,
+                         memory::String=DEFAULT_WORKER_MEMORY,
+                         service_account_name=nothing,
+                         base_obj=kuber_obj(ctx, EMPTY_POD))
     ko = base_obj
     ko.metadata.name = "$(driver_name)-worker-$port"
     cmdo = `$cmd --bind-to=0:$port`
-    if isnothing(image)
-        self = self_pod(ctx)
-        if length(self.spec.containers) > 1
-            error("`default_pod` called with `image = nothing`, driver pod must contain a single container: use `configure` closure kwarg to set worker images manually.")
-        end
-        image = last(self.spec.containers).image
-    end
     push!(ko.spec.containers,
           json(Dict("name" => "$(driver_name)-worker-$port",
                     "image" => image,
@@ -47,20 +57,9 @@ function default_pod(ctx, port, cmd::Cmd, driver_name::String; image=nothing, me
                                                            "cpu" => cpu)),
                                         "limit"    => Dict("memory" => memory,
                                                            "cpu" => cpu))))
-    if !isnothing(serviceAccountName)
-        ko.spec.serviceAccountName = serviceAccountName
+    if service_account_name !== nothing
+        ko.spec.serviceAccountName = service_account_name
     end
+
     return ko
-end
-
-function default_pods_and_context(namespace=current_namespace(); configure, ports, driver_name::String="driver", cmd::Cmd=`julia $(worker_arg())`, kwargs...)
-    ctx = KuberContext()
-    Kuber.set_api_versions!(ctx; verbose=false)
-    set_ns(ctx, namespace)
-
-    # Avoid using a generator with `Dict` as any raised exception would be displayed twice:
-    # https://github.com/JuliaLang/julia/issues/33147
-    pods = Dict([port => configure(default_pod(ctx, port, cmd, driver_name; kwargs...)) for port in ports])
-
-    return pods, ctx
 end

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -7,9 +7,8 @@ const EMPTY_POD =
                              "affinity" => Dict())))
 
 
-function kuber_context(namespace=current_namespace())
+function kuber_context(namespace)
     ctx = KuberContext()
-    Kuber.set_api_versions!(ctx; verbose=false)
     set_ns(ctx, namespace)
     return ctx
 end

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -35,7 +35,6 @@ if !haskey(ENV, "K8S_CLUSTER_MANAGERS_TEST_IMAGE")
     run(`docker build -t $TEST_IMAGE $PKG_DIR`)
 
     # Alternate build call which works on Apple Silicon
-    # run(`docker build --platform x86_64 -t $TEST_IMAGE $PKG_DIR`)
     # run(pipeline(`docker save $TEST_IMAGE`, `minikube ssh --native-ssh=false -- docker load`))
 end
 
@@ -77,7 +76,7 @@ let job_name = "test-success"
                 ko.spec.containers[1].imagePullPolicy = "Never"
                 return ko
             end
-            K8sClusterManagers.addprocs_pod(1; configure, retry_seconds=60, memory="750M")
+            addprocs(K8sClusterManager(1; configure, retry_seconds=60, memory="750M"))
 
             println("Num Processes: ", nprocs())
             for i in workers()
@@ -120,7 +119,7 @@ let job_name = "test-success"
             @test pod_exists(worker_pod)
 
             @test pod_phase(manager_pod) == "Succeeded"
-            @test_broken pod_phase(worker_pod) == "Succeeded"
+            @test pod_phase(worker_pod) == "Succeeded"
 
             @test length(matches) == 1
             @test matches[1][:worker_id] == "2"

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -1,9 +1,8 @@
 @testset "K8sClusterManager" begin
     @testset "pods not found" begin
-        ctx = _kuber_context()
         withenv("HOSTNAME" => "localhost") do
             try
-                K8sClusterManager(1; _ctx=ctx)
+                K8sClusterManager(1; _ctx=KUBER_CONTEXT)
             catch ex
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -1,8 +1,9 @@
 @testset "K8sClusterManager" begin
     @testset "pods not found" begin
+        ctx = _kuber_context()
         withenv("HOSTNAME" => "localhost") do
             try
-                K8sClusterManager(1; _ctx=KUBER_CONTEXT)
+                K8sClusterManager(1; _ctx=ctx)
             catch ex
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -1,8 +1,8 @@
-@testset "addprocs_pod" begin
+@testset "K8sClusterManager" begin
     @testset "pods not found" begin
         withenv("HOSTNAME" => "localhost") do
             try
-                K8sClusterManagers.addprocs_pod(1)
+                K8sClusterManager(1; _ctx=KUBER_CONTEXT)
             catch ex
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -6,6 +6,7 @@
             catch ex
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1
+                rethrow()
             end
         end
     end

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -1,12 +1,15 @@
 @testset "K8sClusterManager" begin
     @testset "pods not found" begin
+        ctx = KuberContext()
         withenv("HOSTNAME" => "localhost") do
             try
-                K8sClusterManager(1; _ctx=KUBER_CONTEXT)
+                K8sClusterManager(1; _ctx=ctx)
             catch ex
+                # Show the original stacktrace if an unexpected error occurred.
+                ex isa Swagger.ApiException || rethrow()
+
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1
-                rethrow()
             end
         end
     end

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -1,9 +1,8 @@
 @testset "self_pod" begin
     @testset "non-nested exceptions" begin
-        ctx = KuberContext()
         withenv("HOSTNAME" => "localhost") do
             try
-                K8sClusterManagers.self_pod(ctx)
+                K8sClusterManagers.self_pod(KUBER_CONTEXT)
             catch ex
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -1,8 +1,9 @@
 @testset "self_pod" begin
     @testset "non-nested exceptions" begin
+        ctx = KuberContext()
         withenv("HOSTNAME" => "localhost") do
             try
-                K8sClusterManagers.self_pod(KUBER_CONTEXT)
+                K8sClusterManagers.self_pod(ctx)
             catch ex
                 # Show the original stacktrace if an unexpected error occurred.
                 ex isa Swagger.ApiException || rethrow()

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -1,8 +1,9 @@
 @testset "self_pod" begin
     @testset "non-nested exceptions" begin
+        ctx = _kuber_context()
         withenv("HOSTNAME" => "localhost") do
             try
-                K8sClusterManagers.self_pod(KUBER_CONTEXT)
+                K8sClusterManagers.self_pod(ctx)
             catch ex
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -4,6 +4,9 @@
             try
                 K8sClusterManagers.self_pod(KUBER_CONTEXT)
             catch ex
+                # Show the original stacktrace if an unexpected error occurred.
+                ex isa Swagger.ApiException || rethrow()
+
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1
             end

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -1,9 +1,8 @@
 @testset "self_pod" begin
     @testset "non-nested exceptions" begin
-        ctx = _kuber_context()
         withenv("HOSTNAME" => "localhost") do
             try
-                K8sClusterManagers.self_pod(ctx)
+                K8sClusterManagers.self_pod(KUBER_CONTEXT)
             catch ex
                 @test ex isa Swagger.ApiException
                 @test length(Base.catch_stack()) == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,8 +11,16 @@ using kubectl_jll: kubectl
 
 Mocking.activate()
 
-# Re-use the same Kuber context throughout the tests
-const KUBER_CONTEXT = K8sClusterManagers.kuber_context()
+# Re-use the same Kuber context throughout the tests. Note we cannot just set this as a load
+# time constant as it depends on K8sClusterManagers being initialized first.
+const KUBER_CONTEXT = Ref{KuberContext}()
+
+function _kuber_context()
+    if !isassigned(KUBER_CONTEXT)
+        KUBER_CONTEXT[] = K8sClusterManagers.kuber_context()
+    end
+    return KUBER_CONTEXT[]
+end
 
 
 @testset "K8sClusterManagers" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,8 @@ const KUBER_CONTEXT = Ref{KuberContext}()
 
 function _kuber_context()
     if !isassigned(KUBER_CONTEXT)
-        KUBER_CONTEXT[] = K8sClusterManagers.kuber_context()
+        # KUBER_CONTEXT[] = K8sClusterManagers.kuber_context()
+        KUBER_CONTEXT[] = KuberContext()
     end
     return KUBER_CONTEXT[]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,9 @@ using kubectl_jll: kubectl
 
 Mocking.activate()
 
+# Re-use the same Kuber context throughout the tests
+const KUBER_CONTEXT = K8sClusterManagers.kuber_context()
+
 
 @testset "K8sClusterManagers" begin
     include("namespace.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,9 +11,6 @@ using kubectl_jll: kubectl
 
 Mocking.activate()
 
-# Re-use the same Kuber context throughout the tests.
-const KUBER_CONTEXT = KuberContext()
-
 @testset "K8sClusterManagers" begin
     include("namespace.jl")
     include("pod.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,18 +11,8 @@ using kubectl_jll: kubectl
 
 Mocking.activate()
 
-# Re-use the same Kuber context throughout the tests. Note we cannot just set this as a load
-# time constant as it depends on K8sClusterManagers being initialized first.
-const KUBER_CONTEXT = Ref{KuberContext}()
-
-function _kuber_context()
-    if !isassigned(KUBER_CONTEXT)
-        # KUBER_CONTEXT[] = K8sClusterManagers.kuber_context()
-        KUBER_CONTEXT[] = KuberContext()
-    end
-    return KUBER_CONTEXT[]
-end
-
+# Re-use the same Kuber context throughout the tests.
+const KUBER_CONTEXT = KuberContext()
 
 @testset "K8sClusterManagers" begin
     include("namespace.jl")


### PR DESCRIPTION
Fixes https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/13

Overview of the changes:
- Renamed `K8sNativeManager` to `K8sClusterManager`.
- Since the `addprocs` function typically handles specifying defaults for `exename` and `exeflags` I needed to move the worker pod spec generation into the `launch` method. Doing this required changes to what was stored within the `K8sClusterManager` struct.
- If a user attempts to launch a k8s cluster without specifying an `image` while running the code outside of a pod an exception will be thrown. This check is now done in the `K8sClusterManager` constructor to avoid having the exception raised inside of a task (how `launch` is called).
- Added a `K8sClusterManager` constructor that takes number of worker to launch
- Stored the pod name in the worker config userdata inside a `NamedTuple`. Should allow for additions without breaking the code.
- Only create a single `KuberContext` instance while testing (reduces noise)
- Avoid defining `kill` and `manage` methods for our cluster manager as we're not adding value. The default `kill` will remotely call `exit` on the workers which allows the worker pods to complete instead of always error.