### PR TITLE
Drop Kuber.jl dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,15 +13,13 @@ kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 JSON = "0.21"
 Mocking = "0.7"
 Mustache = "1"
-Swagger = "0.2"
 julia = "1.3"
 kubectl_jll = "1.20.0"
 
 [extras]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-Swagger = "2d69052b-6a58-5cd9-a030-a48559c324ac"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LibGit2", "Mustache", "Swagger", "Test"]
+test = ["LibGit2", "Mustache", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,8 @@ kubectl_jll = "1.20.0"
 [extras]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LibGit2", "Mustache", "Test"]
+test = ["LibGit2", "Mustache", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "5aeab163-63d2-4171-9fbf-e22244d80acb"
 version = "0.0.2"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Kuber = "87e52247-8a1b-5e01-9430-8fbcac83a23a"

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,11 @@ version = "0.0.2"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-Kuber = "87e52247-8a1b-5e01-9430-8fbcac83a23a"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 
 [compat]
 JSON = "0.21"
-Kuber = "0.4.0"
 Mocking = "0.7"
 Mustache = "1"
 Swagger = "0.2"

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ as:
 
 ```julia
 function my_gpu_configurator(pod)
-    manager_container = pod["spec"]["containers"][1]
-    manager_container["resources"]["limits"]["nvidia.com/gpu"] = 1
+    worker_container = pod["spec"]["containers"][1]
+    worker_container["resources"]["limits"]["nvidia.com/gpu"] = 1
     return pod
 end
 ```

--- a/README.md
+++ b/README.md
@@ -62,11 +62,9 @@ type. `Kuber.jl` makes it convenient to manipulate this `pod`, by letting you do
 as:
 
 ```julia
-function my_configurator(pod)
-    push!(pod.spec.tolerations,
-          Dict("key" => "gpu",
-               "operator" => "Equal",
-               "value" => "true"))
+function my_gpu_configurator(pod)
+    manager_container = pod["spec"]["containers"][1]
+    manager_container["resources"]["limits"]["nvidia.com/gpu"] = 1
     return pod
 end
 ```
@@ -74,8 +72,9 @@ end
 To get an example instance of `pod` that might be passed into the `configure`, call
 
 ```julia
-using K8sClusterManagers, Kuber
-pod = K8sClusterManagers.worker_pod_spec(KuberContext(), port=0, cmd=`julia`, driver_name="driver", image="julia")
+using K8sClusterManagers, JSON
+pod = K8sClusterManagers.worker_pod_spec(port=8080, cmd=`julia`, driver_name="driver", image="julia")
+JSON.print(pod, 4)
 ```
 
 

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -6,7 +6,7 @@ using JSON: JSON
 using Mocking: Mocking, @mock
 using kubectl_jll
 
-export K8sClusterManager, isk8s
+export K8sClusterManager, KubeError, isk8s
 
 
 function __init__()

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -3,36 +3,17 @@ module K8sClusterManagers
 using DataStructures: DefaultOrderedDict, OrderedDict
 using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie
 using JSON: JSON
-using Kuber
 using Mocking: Mocking, @mock
 using kubectl_jll
 
 export K8sClusterManager, isk8s
 
 
-const KUBECTL_PROXY_PROCESS = Ref{Base.Process}()
-
-function restart_kubectl_proxy()
-    # Note: "KUBECTL_PROXY_PORT" is a made up environmental variable and is not supported by
-    # `kubectl proxy`. The default port (8001) is what `kubectl proxy` uses when `--port` is
-    # not specified.
-    port = get(ENV, "KUBECTL_PROXY_PORT", 8001)
-    if isassigned(KUBECTL_PROXY_PROCESS)
-        kill(KUBECTL_PROXY_PROCESS[])
-    end
-    kubectl() do exe
-        KUBECTL_PROXY_PROCESS[] = run(`$exe proxy --port=$port`; wait=false)
-    end
-end
-
 function __init__()
     if !kubectl_jll.is_available()
         error("kubectl_jll does not support the current platform. See: ",
               "https://github.com/JuliaBinaryWrappers/kubectl_jll.jl#platforms")
     end
-
-    # Kuber.jl expects that Kubernetes API server is available via: http://localhost:8001
-    restart_kubectl_proxy()
 end
 
 include("namespace.jl")

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -1,7 +1,8 @@
 module K8sClusterManagers
 
+using DataStructures: DefaultOrderedDict, OrderedDict
 using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie
-using JSON
+using JSON: JSON
 using Kuber
 using Mocking: Mocking, @mock
 using kubectl_jll

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -96,8 +96,7 @@ function wait_for_pod_init(manager::K8sClusterManager, pod)
 end
 
 function worker_pod_spec(manager::K8sClusterManager; kwargs...)
-    pod = worker_pod_spec(manager.ctx;
-                          driver_name=manager.driver_name,
+    pod = worker_pod_spec(; driver_name=manager.driver_name,
                           image=manager.image,
                           cpu=manager.cpu,
                           memory=manager.memory,
@@ -122,7 +121,7 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
             worker_pod_spec(manager; port=port, cmd=cmd)
         end
 
-        pod = manager.configure(pod)
+        pod = kuber_obj(manager.ctx, JSON.json(manager.configure(pod)))
 
         start = time()
         try

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -65,10 +65,11 @@ end
 
 Delete the pod with the given `name`.
 """
-function delete_pod(name::AbstractString)
+function delete_pod(name::AbstractString; wait::Bool=true)
     err = IOBuffer()
     kubectl() do exe
-        run(pipeline(ignorestatus(`$exe delete pod/$name`), stderr=err))
+        cmd = `$exe delete pod/$name --wait=$wait`
+        run(pipeline(ignorestatus(cmd), stdout=devnull, stderr=err))
     end
 
     err.size > 0 && throw(KubeError(err))

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -44,8 +44,9 @@ Create a pod based upon the JSON-compatible `manifest`.
 function create_pod(manifest::AbstractDict)
     # As `kubectl create` can create any resource we'll restrict this function to only
     # creating "Pod" resources.
-    if manifest["kind"] != "Pod"
-        error("Manifest expected to be of kind \"Pod\" and not \"$(manifest["kind"])\"")
+    kind = manifest["kind"]
+    if kind != "Pod"
+        throw(ArgumentError("Manifest expected to be of kind \"Pod\" and not \"$kind\""))
     end
 
     err = IOBuffer()
@@ -80,7 +81,7 @@ end
 """
     worker_pod_spec(pod=POD_TEMPLATE; kwargs...)
 
-Generate pod specification representing a Julia worker inside a single container.
+Generate a pod specification for a Julia worker inside a container.
 """
 function worker_pod_spec(pod::AbstractDict=POD_TEMPLATE; kwargs...)
     return worker_pod_spec!(deepcopy(pod); kwargs...)

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -72,9 +72,9 @@ let job_name = "test-success"
             using Distributed, K8sClusterManagers
 
             # Avoid trying to pull local-only image
-            function configure(ko)
-                ko.spec.containers[1].imagePullPolicy = "Never"
-                return ko
+            function configure(pod)
+                pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
+                return pod
             end
             addprocs(K8sClusterManager(1; configure, retry_seconds=60, memory="750M"))
 

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -73,7 +73,8 @@ randsuffix(len=5) = randstring(['a':'z'; '0':'9'], len)
 
     # Note: We don't need to use the `TEST_IMAGE` here but it avoid having to download
     # another Docker image.
-    pod_spec = K8sClusterManagers.worker_pod_spec(port=8080, cmd=`julia`, driver_name=driver_name, image=TEST_IMAGE, memory="16M")
+    kwargs = (; port=8080, cmd=`julia`, driver_name, image=TEST_IMAGE, memory="16M")
+    pod_spec = K8sClusterManagers.worker_pod_spec(; kwargs...)
 
     # Overwrite some parts of the specification
     pod_spec["metadata"]["name"] = driver_name

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -4,9 +4,9 @@
             K8sClusterManager(1)
         catch ex
             # Show the original stacktrace if an unexpected error occurred.
-            ex isa K8sClusterManagers.KubeError || rethrow()
+            ex isa KubeError || rethrow()
 
-            @test ex isa K8sClusterManagers.KubeError
+            @test ex isa KubeError
             @test length(Base.catch_stack()) == 1
         end
     end

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -4,9 +4,9 @@
             K8sClusterManager(1)
         catch ex
             # Show the original stacktrace if an unexpected error occurred.
-            ex isa Swagger.ApiException || rethrow()
+            ex isa K8sClusterManagers.KubeError || rethrow()
 
-            @test ex isa Swagger.ApiException
+            @test ex isa K8sClusterManagers.KubeError
             @test length(Base.catch_stack()) == 1
         end
     end

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -1,8 +1,7 @@
 @testset "K8sClusterManager" begin
     @testset "pods not found" begin
-        ctx = KuberContext()
         try
-            K8sClusterManager(1; _ctx=ctx)
+            K8sClusterManager(1)
         catch ex
             # Show the original stacktrace if an unexpected error occurred.
             ex isa Swagger.ApiException || rethrow()

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -1,3 +1,14 @@
+@testset "KubeError" begin
+    msg = "Error from server (NotFound): pods \"localhost\" not found"
+    @test sprint(Base.showerror, KubeError(msg)) == "KubeError: $msg"
+end
+
+@testset "create_pod" begin
+    @testset "non-pod" begin
+        @test_throws ErrorException create_pod(Dict("kind" => "Job"))
+    end
+end
+
 @testset "worker_pod_spec" begin
     kwargs = (; port=8080, cmd=`julia`, driver_name="driver", image="julia")
     pod = K8sClusterManagers.worker_pod_spec(; kwargs...)

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -5,7 +5,7 @@ end
 
 @testset "create_pod" begin
     @testset "non-pod" begin
-        @test_throws ErrorException create_pod(Dict("kind" => "Job"))
+        @test_throws ArgumentError create_pod(Dict("kind" => "Job"))
     end
 end
 

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -2,7 +2,8 @@
     kwargs = (; port=8080, cmd=`julia`, driver_name="driver", image="julia")
     pod = K8sClusterManagers.worker_pod_spec(; kwargs...)
 
-    @test keys(pod) == Set(["kind", "metadata", "spec"])
+    @test keys(pod) == Set(["apiVersion", "kind", "metadata", "spec"])
+    @test pod["apiVersion"] == "v1"
     @test pod["kind"] == "Pod"
     @test pod["metadata"]["name"] == "driver-worker-8080"
     @test pod["spec"]["restartPolicy"] == "Never"

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -1,3 +1,24 @@
+@testset "worker_pod_spec" begin
+    kwargs = (; port=8080, cmd=`julia`, driver_name="driver", image="julia")
+    pod = K8sClusterManagers.worker_pod_spec(; kwargs...)
+
+    @test keys(pod) == Set(["kind", "metadata", "spec"])
+    @test pod["kind"] == "Pod"
+    @test pod["metadata"]["name"] == "driver-worker-8080"
+    @test pod["spec"]["restartPolicy"] == "Never"
+    @test length(pod["spec"]["containers"]) == 1
+
+    worker = pod["spec"]["containers"][1]
+    @test keys(worker) == Set(["name", "image", "command", "resources"])
+    @test worker["name"] == "worker"
+    @test worker["image"] == "julia"
+    @test worker["command"] == ["julia", "--bind-to=0:8080"]
+    @test worker["resources"]["requests"]["cpu"] == DEFAULT_WORKER_CPU
+    @test worker["resources"]["requests"]["memory"] == DEFAULT_WORKER_MEMORY
+    @test worker["resources"]["limits"]["cpu"] == DEFAULT_WORKER_CPU
+    @test worker["resources"]["limits"]["memory"] == DEFAULT_WORKER_MEMORY
+end
+
 @testset "isk8s" begin
     pod_id = "pode773d78d-9f0d-4003-a6e8-9bef75b89298/" *
              "b52d083fb1f5b45d998895ab758d10fa36b2a53f3bf3128d7cf1d6d36bc67bd6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,9 @@ using Distributed
 using K8sClusterManagers
 using K8sClusterManagers: DEFAULT_NAMESPACE, NAMESPACE_FILE
 using K8sClusterManagers: DEFAULT_WORKER_CPU, DEFAULT_WORKER_MEMORY
-using Kuber: KuberContext
 using LibGit2: LibGit2
 using Mocking: Mocking, @patch, apply
 using Mustache: Mustache, render
-using Swagger: Swagger
 using Test
 using kubectl_jll: kubectl
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,11 @@ using Distributed
 using K8sClusterManagers
 using K8sClusterManagers: DEFAULT_NAMESPACE, NAMESPACE_FILE
 using K8sClusterManagers: DEFAULT_WORKER_CPU, DEFAULT_WORKER_MEMORY
+using K8sClusterManagers: create_pod, delete_pod, get_pod
 using LibGit2: LibGit2
 using Mocking: Mocking, @patch, apply
 using Mustache: Mustache, render
+using Random: randstring
 using Test
 using kubectl_jll: kubectl
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Distributed
 using K8sClusterManagers
 using K8sClusterManagers: DEFAULT_NAMESPACE, NAMESPACE_FILE
+using K8sClusterManagers: DEFAULT_WORKER_CPU, DEFAULT_WORKER_MEMORY
 using Kuber: KuberContext
 using LibGit2: LibGit2
 using Mocking: Mocking, @patch, apply


### PR DESCRIPTION
Using Kuber.jl seems like more trouble than it's worth at the moment. 

- Kuber objects only support very basic `getfield` and `setfield` access requiring a work around when non-valid field strings are required. e.g. the updated GPU configuration function mentioned in the README would need to be written as:
    ```julia
    function my_gpu_configurator(pod)
        limits = something(pod.spec.containers[1].resources.limits, Dict())
        limits["nvidia.com/gpu"] = 1
        pod.spec.containers[1].resources.limits = limits
        return pod
    end
    ```
- `kube_obj` requires a JSON string or `Dict`. It cannot accept `AbstractDict`.
- Kuber.jl is the reason we're required to start the `kubectl proxy` command
- `KuberContext` has been problematic in the CI environment (https://github.com/beacon-biosignals/K8sClusterManagers.jl/pull/31#issuecomment-824087436)
- We want to move towards having users being able to pass in the worker pod manifest

Update: Additional reasons to get rid of Kuber.jl:
- Sending too many requests through the `kubectl proxy` can cause exceptions to be raised which require requests to be retried. Such failures can also cause the `kubectl proxy` to crash which results in the user needing to know how to restart the proxy command
