### PR TITLE
Define manage for `K8sClusterManager`

### DIFF
--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -162,3 +162,7 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
         @warn "$(length(erray)) errors with the same type as" exception=(e, backtrace)
     end
 end
+
+function Distributed.manage(manager::K8sClusterManager, id::Integer, config::WorkerConfig, op::Symbol)
+    return nothing
+end

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -125,6 +125,9 @@ let job_name = "test-success"
             @test length(matches) == 1
             @test matches[1][:worker_id] == "2"
             @test matches[1][:pod_name] == worker_pod
+
+            # Ensure there are no unexpected error messages in the log
+            @test !occursin(r"\bError\b"i, manager_log)
         ]
 
         # Display details to assist in debugging the failure


### PR DESCRIPTION
I noticed the cluster tests had this in the manager log:
```
error in running finalizer: MethodError(f=Distributed.manage, args=(K8sClusterManagers.K8sClusterManager(ports=Array{UInt16, (1,)}[0x2329], driver_name="test-success-t4blj", image="k8s-cluster-managers:faf3fa9-dirty-35684", cpu="1", memory="750M", retry_seconds=60, configure=Main.configure), 2, Distributed.WorkerConfig(io=nothing, host="172.17.0.4", port=9001, count=nothing, exename=nothing, exeflags=nothing, userdata=(pod_name="test-success-t4blj-worker-9001",), tunnel=nothing, multiplex=nothing, forward=nothing, bind_addr="172.17.0.4", sshflags=nothing, max_parallel=nothing, connect_at=("172.17.0.4", 9001), process=nothing, ospid=1, environ=Base.Dict{Any, Any}(slots=Array{UInt8, (16,)}[0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], keys=Array{Any, (16,)}[
  #<null>,
  :cpu_threads,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>,
  #<null>], vals=Array{Any, (16,)}[#<null>, 3, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>, #<null>], ndel=0, count=1, age=0x0000000000000001, idxfloor=1, maxprobe=0), ident=nothing, connect_idents=nothing, enable_threaded_blas=nothing), :finalize), world=0x00000000000073b6)
jl_method_error_bare at /buildworker/worker/package_linuxaarch64/build/src/gf.c:1812
jl_method_error at /buildworker/worker/package_linuxaarch64/build/src/gf.c:1830
jl_lookup_generic_ at /buildworker/worker/package_linuxaarch64/build/src/gf.c:2400 [inlined]
jl_apply_generic at /buildworker/worker/package_linuxaarch64/build/src/gf.c:2415
#47 at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.6/Distributed/src/cluster.jl:603
_jl_invoke at /buildworker/worker/package_linuxaarch64/build/src/gf.c:2237 [inlined]
jl_apply_generic at /buildworker/worker/package_linuxaarch64/build/src/gf.c:2419
jl_apply at /buildworker/worker/package_linuxaarch64/build/src/julia.h:1703 [inlined]
run_finalizer at /buildworker/worker/package_linuxaarch64/build/src/gc.c:278
jl_gc_run_finalizers_in_list at /buildworker/worker/package_linuxaarch64/build/src/gc.c:365
run_finalizers at /buildworker/worker/package_linuxaarch64/build/src/gc.c:394 [inlined]
jl_gc_run_all_finalizers at /buildworker/worker/package_linuxaarch64/build/src/gc.c:480
jl_atexit_hook at /buildworker/worker/package_linuxaarch64/build/src/init.c:240
repl_entrypoint at /buildworker/worker/package_linuxaarch64/build/src/jlapi.c:703
main at julia (unknown line)
__libc_start_main at /lib/aarch64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x4008b7)
unknown function (ip: 0x4008b7)
```
This was caused by not defining a `Distributed.manage` method for `K8sClusterManager`. I thought this was optional as the `Distributed.kill` has a fallback for `ClusterManager` subtypes.