### PR TITLE
Allow multiple calls to `addprocs`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [targets]
-test = ["LibGit2", "Mustache", "Random", "Test"]
+test = ["LibGit2", "Mustache", "Random", "Test", "YAML"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 
 [compat]
@@ -19,9 +20,8 @@ kubectl_jll = "1.20.0"
 [extras]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [targets]
-test = ["LibGit2", "Mustache", "Random", "Test", "YAML"]
+test = ["LibGit2", "Mustache", "Test", "YAML"]

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ run with [minikube](https://minikube.sigs.k8s.io/).
 ### Minikube
 
 1. [Install Docker or Docker Desktop](https://docs.docker.com/get-docker/)
-2. If using Docker Desktop: set the resources to a minimum of 3 CPUs and 2.25 GB Memory
+2. If using Docker Desktop: set the resources to a minimum of 4 CPUs and 2.25 GB Memory
 3. [Install minikube](https://minikube.sigs.k8s.io/docs/start/)
 4. Start the Kubernetes cluster: `minikube start`
 5. Use the in-cluster Docker daemon for image builds: `eval $(minikube docker-env)`

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -4,6 +4,7 @@ using DataStructures: DefaultOrderedDict, OrderedDict
 using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie
 using JSON: JSON
 using Mocking: Mocking, @mock
+using Random: rand
 using kubectl_jll
 
 export K8sClusterManager, KubeError, isk8s

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -131,6 +131,7 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
                     pod_name = create_pod(worker_manifest)
                     break
                 catch e
+                    @error sprint(Base.showerror, e)
                     sleep(rand() * sleeptime)
                 end
             end

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -97,19 +97,16 @@ function worker_pod_spec(pod::AbstractDict=POD_TEMPLATE; kwargs...)
 end
 
 function worker_pod_spec!(pod::AbstractDict;
-                          port::Integer,
                           cmd::Cmd,
                           driver_name::String,
                           image::String,
                           cpu=DEFAULT_WORKER_CPU,
                           memory=DEFAULT_WORKER_MEMORY,
                           service_account_name=nothing)
-    pod["metadata"]["generateName"] = "$(driver_name)-worker-$port"
+    pod["metadata"]["generateName"] = "$(driver_name)-worker-"
 
     # Set a label with the manager name to support easy termination of all workers
     pod["metadata"]["labels"]["manager"] = driver_name
-
-    cmd = `$cmd --bind-to=0:$port`
 
     worker_container =
         rdict("name" => "worker",

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -104,7 +104,7 @@ function worker_pod_spec!(pod::AbstractDict;
                           cpu=DEFAULT_WORKER_CPU,
                           memory=DEFAULT_WORKER_MEMORY,
                           service_account_name=nothing)
-    pod["metadata"]["name"] = "$(driver_name)-worker-$port"
+    pod["metadata"]["generateName"] = "$(driver_name)-worker-$port"
 
     # Set a label with the manager name to support easy termination of all workers
     pod["metadata"]["labels"]["manager"] = driver_name

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -191,8 +191,10 @@ let job_name = "test-multi-addprocs"
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
-            addprocs(K8sClusterManager(1; configure, retry_seconds=60, memory="300Mi"))
-            addprocs(K8sClusterManager(1; configure, retry_seconds=60, memory="300Mi"))
+
+            mgr = K8sClusterManager(1; configure, retry_seconds=60, cpu="0.5", memory="300Mi")
+            addprocs(mgr)
+            addprocs(mgr)
 
             println("Num Processes: ", nprocs())
             for i in workers()
@@ -237,7 +239,9 @@ let job_name = "test-multi-addprocs"
 
         # Display details to assist in debugging the failure
         if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
-            report(job_name, "manager" => manager_pod, map(w -> "worker" => w, worker_pods)...)
+            n = length(workers)
+            worker_pairs = map((i, w) -> "worker $i/$n", enumerate(worker_pods))
+            report(job_name, "manager" => manager_pod, worker_pairs...)
         end
     end
 end

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -150,9 +150,7 @@ let job_name = "test-success"
         # - Insufficient cluster resources (pod stuck in the "Pending" status)
         # - Local Docker image does not exist (ErrImageNeverPull)
         @info "Waiting for $job_name job. This could take up to 4 minutes..."
-        timedwait(4 * 60; pollint=10) do
-            !isempty(get_job("test-success", jsonpath="{.status..type}"))
-        end
+        wait_job(job_name, condition=!isempty, timeout=4 * 60)
 
         manager_pod = first(pod_names("job-name" => job_name))
         worker_pod = first(pod_names("manager" => manager_pod))
@@ -161,7 +159,7 @@ let job_name = "test-success"
         matches = collect(eachmatch(POD_NAME_REGEX, manager_log))
 
         test_results = [
-            @test get_job("test-success", jsonpath="{.status..type}") == "Complete"
+            @test get_job(job_name, jsonpath="{.status..type}") == "Complete"
 
             @test pod_exists(manager_pod)
             @test pod_exists(worker_pod)

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -38,34 +38,6 @@ if !haskey(ENV, "K8S_CLUSTER_MANAGERS_TEST_IMAGE")
     # run(pipeline(`docker save $TEST_IMAGE`, `minikube ssh --native-ssh=false -- docker load`))
 end
 
-pod_exists(pod_name) = kubectl(exe -> success(`$exe get pod/$pod_name`))
-
-# Will fail if called and the job is in state "Waiting"
-pod_logs(pod_name) = kubectl(exe -> read(ignorestatus(`$exe logs $pod_name`), String))
-
-# https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
-pod_phase(pod_name) = kubectl(exe -> read(`$exe get pod/$pod_name -o 'jsonpath={.status.phase}'`, String))
-
-function pod_names(labels::Pair...)
-    selectors = Dict{String,String}(labels)
-    selector = join(map(p -> join(p, '='), collect(pairs(selectors))), ',')
-
-    # Adapted from: https://kubernetes.io/docs/concepts/workloads/controllers/job/#running-an-example-job
-    jsonpath = "{range .items[*]}{.metadata.name}{\"\\n\"}{end}"
-    output = kubectl() do exe
-        read(`$exe get pods -l $selector -o=jsonpath=$jsonpath`, String)
-    end
-    return split(output, '\n')
-end
-
-# Use the double-quoted flow scalar style to allow us to have a YAML string which includes
-# newlines without being aware of YAML indentation (block styles)
-#
-# The double-quoted style allows us to use escape sequences via `\` but requires us to
-# escape uses of `\` and `"`. It so happens that `escape_string` follows the same rules
-escape_yaml_string(str::AbstractString) = escape_string(str)
-
-randsuffix(len=5) = randstring(['a':'z'; '0':'9'], len)
 
 @testset "pod control" begin
     pod_control_manifest = YAML.load_file(joinpath(@__DIR__, "pod-control.yaml"))
@@ -169,12 +141,8 @@ let job_name = "test-success"
 
         command = ["julia"]
         args = ["-e", escape_yaml_string(code)]
-        config = render(JOB_TEMPLATE; job_name, image=TEST_IMAGE, command, args)
-        kubectl() do exe
-            open(`$exe apply --force -f -`, "w", stdout) do p
-                write(p.in, config)
-            end
-        end
+        manifest = render(JOB_TEMPLATE; job_name, image=TEST_IMAGE, command, args)
+        k8s_create(IOBuffer(manifest))
 
         # Wait for job to reach status: "Complete" or "Failed".
         #
@@ -182,11 +150,8 @@ let job_name = "test-success"
         # - Insufficient cluster resources (pod stuck in the "Pending" status)
         # - Local Docker image does not exist (ErrImageNeverPull)
         @info "Waiting for $job_name job. This could take up to 4 minutes..."
-        job_status_subcmd = `get job/$job_name -o 'jsonpath={..status..type}'`
         timedwait(4 * 60; pollint=10) do
-            kubectl() do exe
-                !isempty(read(`$exe $job_status_subcmd`, String))
-            end
+            !isempty(get_job("test-success", jsonpath="{.status..type}"))
         end
 
         manager_pod = first(pod_names("job-name" => job_name))
@@ -196,7 +161,7 @@ let job_name = "test-success"
         matches = collect(eachmatch(POD_NAME_REGEX, manager_log))
 
         test_results = [
-            @test kubectl(exe -> read(`$exe $job_status_subcmd`, String)) == "Complete"
+            @test get_job("test-success", jsonpath="{.status..type}") == "Complete"
 
             @test pod_exists(manager_pod)
             @test pod_exists(worker_pod)
@@ -214,47 +179,7 @@ let job_name = "test-success"
 
         # Display details to assist in debugging the failure
         if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
-            kubectl() do exe
-                cmd = `$exe describe job/$job_name`
-                @info "Describe job:\n" * read(ignorestatus(cmd), String)
-            end
-
-            # Note: A job doesn't contain a direct reference to the pod it starts so
-            # re-using the job name can result in us identifying the wrong manager pod.
-            kubectl() do exe
-                cmd = `$exe get pods -L job-name=$job_name`
-                @info "List pods:\n" * read(ignorestatus(cmd), String)
-            end
-
-            if pod_exists(manager_pod)
-                kubectl() do exe
-                    cmd = `$exe describe pod/$manager_pod`
-                    @info "Describe manager pod:\n" * read(cmd, String)
-                end
-            else
-                @info "Manager pod \"$manager_pod\" not found"
-            end
-
-            if pod_exists(worker_pod)
-                kubectl() do exe
-                    cmd = `$exe describe pod/$worker_pod`
-                    @info "Describe worker pod:\n" * read(cmd, String)
-                end
-            else
-                @info "Worker pod \"$worker_pod\" not found"
-            end
-
-            if pod_exists(manager_pod)
-                @info "Logs for manager ($manager_pod):\n" * pod_logs(manager_pod)
-            else
-                @info "No logs for manager ($manager_pod)"
-            end
-
-            if pod_exists(worker_pod)
-                @info "Logs for worker ($worker_pod):\n" * pod_logs(worker_pod)
-            else
-                @info "No logs for worker ($worker_pod)"
-            end
+            report(job_name, "manager" => manager_pod, "worker" => worker_pod)
         end
     end
 end

--- a/test/pod-control.yaml
+++ b/test/pod-control.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-control
+spec:
+  restartPolicy: "Never"
+  containers:
+  - name: sleep
+    image: alpine
+    command: ["sleep"]
+    args: ["60"]

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -17,8 +17,8 @@ end
     @test pod["apiVersion"] == "v1"
     @test pod["kind"] == "Pod"
 
-    @test keys(pod["metadata"]) == Set(["name", "labels"])
-    @test pod["metadata"]["name"] == "driver-worker-8080"
+    @test keys(pod["metadata"]) == Set(["generateName", "labels"])
+    @test pod["metadata"]["generateName"] == "driver-worker-8080"
     @test keys(pod["metadata"]["labels"]) == Set(["manager"])
     @test pod["metadata"]["labels"]["manager"] == "driver"
 

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -10,7 +10,7 @@ end
 end
 
 @testset "worker_pod_spec" begin
-    kwargs = (; port=8080, cmd=`julia`, driver_name="driver", image="julia")
+    kwargs = (; cmd=`julia`, driver_name="driver", image="julia")
     pod = K8sClusterManagers.worker_pod_spec(; kwargs...)
 
     @test keys(pod) == Set(["apiVersion", "kind", "metadata", "spec"])
@@ -18,7 +18,7 @@ end
     @test pod["kind"] == "Pod"
 
     @test keys(pod["metadata"]) == Set(["generateName", "labels"])
-    @test pod["metadata"]["generateName"] == "driver-worker-8080"
+    @test pod["metadata"]["generateName"] == "driver-worker-"
     @test keys(pod["metadata"]["labels"]) == Set(["manager"])
     @test pod["metadata"]["labels"]["manager"] == "driver"
 
@@ -29,7 +29,7 @@ end
     @test keys(worker) == Set(["name", "image", "command", "resources"])
     @test worker["name"] == "worker"
     @test worker["image"] == "julia"
-    @test worker["command"] == ["julia", "--bind-to=0:8080"]
+    @test worker["command"] == ["julia"]
     @test worker["resources"]["requests"]["cpu"] == DEFAULT_WORKER_CPU
     @test worker["resources"]["requests"]["memory"] == DEFAULT_WORKER_MEMORY
     @test worker["resources"]["limits"]["cpu"] == DEFAULT_WORKER_CPU

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,8 @@ using kubectl_jll: kubectl
 
 Mocking.activate()
 
+include("utils.jl")
+
 @testset "K8sClusterManagers" begin
     include("namespace.jl")
     include("pod.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Mocking: Mocking, @patch, apply
 using Mustache: Mustache, render
 using Random: randstring
 using Test
+using YAML: YAML
 using kubectl_jll: kubectl
 
 Mocking.activate()

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,88 @@
+using DataStructures: OrderedDict
+
+function k8s_create(manifest::IO)
+    kubectl() do exe
+        open(`$exe apply --force -f -`, "w", stdout) do p
+            write(p.in, read(manifest))
+        end
+    end
+end
+
+function get_job(name::AbstractString; jsonpath=nothing)
+    output = if jsonpath !== nothing
+        "jsonpath=$jsonpath"
+    else
+        "json"
+    end
+
+    err = IOBuffer()
+    out = kubectl() do exe
+        read(pipeline(ignorestatus(`$exe get job/$name -o $output`), stderr=err), String)
+    end
+
+    err.size > 0 && throw(KubeError(err))
+    return output == "json" ? JSON.parse(out; dicttype=OrderedDict) : out
+end
+
+pod_exists(pod_name) = kubectl(exe -> success(`$exe get pod/$pod_name`))
+
+# Will fail if called and the job is in state "Waiting"
+pod_logs(pod_name) = kubectl(exe -> read(ignorestatus(`$exe logs $pod_name`), String))
+
+# https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+pod_phase(pod_name) = kubectl(exe -> read(`$exe get pod/$pod_name -o 'jsonpath={.status.phase}'`, String))
+
+function pod_names(labels::Pair...)
+    selectors = Dict{String,String}(labels)
+    selector = join(map(p -> join(p, '='), collect(pairs(selectors))), ',')
+
+    # Adapted from: https://kubernetes.io/docs/concepts/workloads/controllers/job/#running-an-example-job
+    jsonpath = "{range .items[*]}{.metadata.name}{\"\\n\"}{end}"
+    output = kubectl() do exe
+        read(`$exe get pods -l $selector -o=jsonpath=$jsonpath`, String)
+    end
+    return split(output, '\n')
+end
+
+# Use the double-quoted flow scalar style to allow us to have a YAML string which includes
+# newlines without being aware of YAML indentation (block styles)
+#
+# The double-quoted style allows us to use escape sequences via `\` but requires us to
+# escape uses of `\` and `"`. It so happens that `escape_string` follows the same rules
+escape_yaml_string(str::AbstractString) = escape_string(str)
+
+randsuffix(len=5) = randstring(['a':'z'; '0':'9'], len)
+
+
+function report(job_name, pods::Pair...)
+    kubectl() do exe
+        cmd = `$exe describe job/$job_name`
+        @info "Describe job:\n" * read(ignorestatus(cmd), String)
+    end
+
+    # Note: A job doesn't contain a direct reference to the pod it starts so
+    # re-using the job name can result in us identifying the wrong manager pod.
+    kubectl() do exe
+        cmd = `$exe get pods -L job-name=$job_name`
+        @info "List pods for job $job_name:\n" * read(ignorestatus(cmd), String)
+    end
+
+    for (title, pod_name) in pods
+        if pod_exists(pod_name)
+            kubectl() do exe
+                cmd = `$exe describe pod $pod_name`
+                @info "Describe $title pod:\n" * read(cmd, String)
+            end
+        else
+            @info "$(titlecase(title)) pod \"$pod_name\" not found"
+        end
+    end
+
+    for (title, pod_name) in pods
+        if pod_exists(pod_name)
+            @info "Logs for $title ($pod_name):\n" * pod_logs(pod_name)
+        else
+            @info "No logs for $title ($pod_name)"
+        end
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/39 by using unique names for each worker pod. Making this change required an update of `create_pod` to retrieve the generated pod name. Once was done it became more obvious that logic for using ports wasn't to avoid port in use issues but rather an attempt to make the pod names unique. The use of ports was then mostly refactored away.

I may break this PR into multiple after I finish debugging the CI.