### PR TITLE
Support `generateName` for worker pods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 JSON = "0.21"
 Mocking = "0.7"
 Mustache = "1"
+YAML = "0.4.6"
 julia = "1.3"
 kubectl_jll = "1.20.0"
 
@@ -21,6 +22,7 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [targets]
-test = ["LibGit2", "Mustache", "Random", "Test"]
+test = ["LibGit2", "Mustache", "Random", "Test", "YAML"]

--- a/test/pod-control.yaml
+++ b/test/pod-control.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-control
+spec:
+  restartPolicy: "Never"
+  containers:
+  - name: sleep
+    image: alpine
+    command: ["sleep"]
+    args: ["60"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Mocking: Mocking, @patch, apply
 using Mustache: Mustache, render
 using Random: randstring
 using Test
+using YAML: YAML
 using kubectl_jll: kubectl
 
 Mocking.activate()


### PR DESCRIPTION
Code changes in place just to support using a generated pod name. Being able to use a unique pod name is important for solving #39. Using a generated pod name will happen in another PR. 

Was originally part of: https://github.com/beacon-biosignals/K8sClusterManagers.jl/pull/41