### PR TITLE
Support `generateName` for worker pods

### DIFF
--- a/src/pod.jl
+++ b/src/pod.jl
@@ -97,19 +97,16 @@ function worker_pod_spec(pod::AbstractDict=POD_TEMPLATE; kwargs...)
 end
 
 function worker_pod_spec!(pod::AbstractDict;
-                          port::Integer,
                           cmd::Cmd,
                           driver_name::String,
                           image::String,
                           cpu=DEFAULT_WORKER_CPU,
                           memory=DEFAULT_WORKER_MEMORY,
                           service_account_name=nothing)
-    pod["metadata"]["name"] = "$(driver_name)-worker-$port"
+    pod["metadata"]["generateName"] = "$(driver_name)-worker-"
 
     # Set a label with the manager name to support easy termination of all workers
     pod["metadata"]["labels"]["manager"] = driver_name
-
-    cmd = `$cmd --bind-to=0:$port`
 
     worker_container =
         rdict("name" => "worker",

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -129,7 +129,7 @@ let job_name = "test-success"
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
-            addprocs(K8sClusterManager(1; configure, retry_seconds=60, memory="750M"))
+            addprocs(K8sClusterManager(1; configure, retry_seconds=60, cpu="0.5", memory="300Mi"))
 
             println("Num Processes: ", nprocs())
             for i in workers()
@@ -152,7 +152,7 @@ let job_name = "test-success"
         wait_job(job_name, condition=!isempty, timeout=4 * 60)
 
         manager_pod = first(pod_names("job-name" => job_name))
-        worker_pod = "$manager_pod-worker-9001"
+        worker_pod = first(pod_names("manager" => manager_pod))
 
         manager_log = pod_logs(manager_pod)
         matches = collect(eachmatch(POD_NAME_REGEX, manager_log))
@@ -177,6 +177,71 @@ let job_name = "test-success"
         # Display details to assist in debugging the failure
         if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
             report(job_name, "manager" => manager_pod, "worker" => worker_pod)
+        end
+    end
+end
+
+let job_name = "test-multi-addprocs"
+    @testset "$job_name" begin
+        code = """
+            using Distributed, K8sClusterManagers
+
+            # Avoid trying to pull local-only image
+            function configure(pod)
+                pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
+                return pod
+            end
+
+            mgr = K8sClusterManager(1; configure, retry_seconds=60, cpu="0.5", memory="300Mi")
+            addprocs(mgr)
+            addprocs(mgr)
+
+            println("Num Processes: ", nprocs())
+            for i in workers()
+                # Return the name of the pod via HOSTNAME
+                println("Worker pod \$i: ", remotecall_fetch(() -> ENV["HOSTNAME"], i))
+            end
+            """
+
+        command = ["julia"]
+        args = ["-e", escape_yaml_string(code)]
+        manifest = render(JOB_TEMPLATE; job_name, image=TEST_IMAGE, command, args)
+        k8s_create(IOBuffer(manifest))
+
+        # Wait for job to reach status: "Complete" or "Failed".
+        @info "Waiting for $job_name job. This could take up to 4 minutes..."
+        wait_job(job_name, condition=!isempty, timeout=4 * 60)
+
+        manager_pod = first(pod_names("job-name" => job_name))
+        worker_pods = pod_names("manager" => manager_pod)
+
+        manager_log = pod_logs(manager_pod)
+        reported_workers = map(m -> m[:pod_name], eachmatch(POD_NAME_REGEX, manager_log))
+
+        test_results = [
+            @test get_job(job_name, jsonpath="{.status..type}") == "Complete"
+
+            @test pod_exists(manager_pod)
+            @test length(worker_pods) == 2
+            @test pod_exists(worker_pods[1])
+            @test pod_exists(worker_pods[2])
+
+            @test pod_phase(manager_pod) == "Succeeded"
+            @test pod_phase(worker_pods[1]) == "Succeeded"
+            @test pod_phase(worker_pods[2]) == "Succeeded"
+
+            @test length(reported_workers) == length(worker_pods)
+            @test Set(reported_workers) == Set(worker_pods)
+
+            # Ensure there are no unexpected error messages in the log
+            @test !occursin(r"\bError\b"i, manager_log)
+        ]
+
+        # Display details to assist in debugging the failure
+        if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
+            n = length(worker_pods)
+            worker_pairs = map((i, w) -> "worker $i/$n", enumerate(worker_pods))
+            report(job_name, "manager" => manager_pod, worker_pairs...)
         end
     end
 end

--- a/test/job.template.yaml
+++ b/test/job.template.yaml
@@ -51,8 +51,8 @@ spec:
         imagePullPolicy: Never  # Avoid attempting to pull local-only images
         resources:
           limits:
-            cpu: 1
-            memory: 750M
+            cpu: 0.5
+            memory: 300Mi
         command: [{{#:command}}"{{{.}}}"{{^.[end]}}, {{/.[end]}}{{/:command}}]
         args: [{{#:args}}"{{{.}}}"{{^.[end]}}, {{/.[end]}}{{/:args}}]
         stdin: true

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -10,15 +10,15 @@ end
 end
 
 @testset "worker_pod_spec" begin
-    kwargs = (; port=8080, cmd=`julia`, driver_name="driver", image="julia")
+    kwargs = (; cmd=`julia`, driver_name="driver", image="julia")
     pod = K8sClusterManagers.worker_pod_spec(; kwargs...)
 
     @test keys(pod) == Set(["apiVersion", "kind", "metadata", "spec"])
     @test pod["apiVersion"] == "v1"
     @test pod["kind"] == "Pod"
 
-    @test keys(pod["metadata"]) == Set(["name", "labels"])
-    @test pod["metadata"]["name"] == "driver-worker-8080"
+    @test keys(pod["metadata"]) == Set(["generateName", "labels"])
+    @test pod["metadata"]["generateName"] == "driver-worker-"
     @test keys(pod["metadata"]["labels"]) == Set(["manager"])
     @test pod["metadata"]["labels"]["manager"] == "driver"
 
@@ -29,7 +29,7 @@ end
     @test keys(worker) == Set(["name", "image", "command", "resources"])
     @test worker["name"] == "worker"
     @test worker["image"] == "julia"
-    @test worker["command"] == ["julia", "--bind-to=0:8080"]
+    @test worker["command"] == ["julia"]
     @test worker["resources"]["requests"]["cpu"] == DEFAULT_WORKER_CPU
     @test worker["resources"]["requests"]["memory"] == DEFAULT_WORKER_MEMORY
     @test worker["resources"]["limits"]["cpu"] == DEFAULT_WORKER_CPU


### PR DESCRIPTION
Fixes #39 by using unique names for each worker pod. It was also noticed that logic for using unique ports wasn't to avoid port conflicts but rather an attempt to make the pod names unique. Because of this the use of ports has mostly been refactored away.

Bonus change: Originally the cluster tests on the CI needed to use 1 node per pod to ensure there was enough CPU resources. As we can request [partial CPU resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) the use of multiple nodes on the CI is probably no longer necessary but I'll leave this in place for now.

Was originally part of: #41