### PR TITLE
Change Codecov comment behaviour

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+# https://docs.codecov.io/docs/pull-request-comments
+comment:
+  behavior: new


### PR DESCRIPTION
It appears that sometimes codecov doesn't update the comment to reflect the current coverage status. This behaviour should make it more obvious if the comment has been updated as the old comment will be deleted and a new one posted.