### PR TITLE
Refactor `Distributed.launch`

### DIFF
--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -108,8 +108,10 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
                 rethrow()
             end
 
+            # Wait a few seconds to allow the worker to start listening to connections at
+            # expected port. If we don't wait long enough we will see a "connection refused"
+            # error (https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/46)
             @info "$pod_name is up"
-
             sleep(2)
 
             config = WorkerConfig()

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -116,7 +116,7 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
             # expected port. If we don't wait long enough we will see a "connection refused"
             # error (https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/46)
             @info "$pod_name is up"
-            sleep(2)
+            sleep(4)
 
             config = WorkerConfig()
             config.host = pod["status"]["podIP"]

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -99,7 +99,6 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
 
     asyncmap(1:manager.np) do i
         pod_name = nothing
-        start = time()
         try
             pod_name = create_pod(worker_manifest)
             status = wait_for_running_pod(pod_name; timeout=manager.retry_seconds)

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -92,7 +92,11 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
     # required.
     cmd = `$exename $exeflags --worker=$(cluster_cookie()) --bind-to=0:$WORKER_PORT`
 
-    worker_manifest = worker_pod_spec(manager; cmd=cmd)
+    worker_manifest = @static if VERSION >= v"1.5"
+        worker_pod_spec(manager; cmd)
+    else
+        worker_pod_spec(manager; cmd=cmd)
+    end
 
     # Note: User-defined `configure` function may or may-not be mutating
     worker_manifest = manager.configure(worker_manifest)

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -101,7 +101,7 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
         @async begin
             pod_name = create_pod(worker_manifest)
 
-            status = try
+            pod = try
                 wait_for_running_pod(pod_name; timeout=manager.retry_seconds)
             catch e
                 delete_pod(pod_name; wait=false)
@@ -115,7 +115,7 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
             sleep(2)
 
             config = WorkerConfig()
-            config.host = status["podIP"]
+            config.host = pod["status"]["podIP"]
             config.port = WORKER_PORT
             config.userdata = (; pod_name=pod_name)
             push!(launched, config)

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -87,6 +87,24 @@ function delete_pod(name::AbstractString; wait::Bool=true)
 end
 
 
+function wait_for_running_pod(name::AbstractString; timeout::Real)
+    status = nothing
+
+    result = timedwait(timeout) do
+        status = get_pod(name)["status"]
+        status["phase"] == "Running"
+    end
+
+    if result === :ok
+        return status
+    else
+        msg = "timed out after waiting for worker $name to start for $timeout seconds, " *
+            "with status:\n" * JSON.json(status, 4)
+        throw(TimeoutException(msg))
+    end
+end
+
+
 """
     worker_pod_spec(pod=POD_TEMPLATE; kwargs...)
 

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -97,6 +97,11 @@ will be raised.
 function wait_for_running_pod(name::AbstractString; timeout::Real)
     pod = nothing
 
+    # `timedwait` requires a floating point data type on earlier versions of Julia
+    @static if VERSION < v"1.5-"
+        timeout = float(timeout)
+    end
+
     result = timedwait(timeout; pollint=1) do
         pod = @mock get_pod(name)
         pod["status"]["phase"] == "Running"

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -97,12 +97,12 @@ will be raised.
 function wait_for_running_pod(name::AbstractString; timeout::Real)
     pod = nothing
 
-    # `timedwait` requires a floating point data type on earlier versions of Julia
+    # `timedwait` requires a floating points for the `secs` argument and `pollint` keyword
     @static if VERSION < v"1.5-"
         timeout = float(timeout)
     end
 
-    result = timedwait(timeout; pollint=1) do
+    result = timedwait(timeout; pollint=1.0) do
         pod = @mock get_pod(name)
         pod["status"]["phase"] == "Running"
     end

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -98,7 +98,7 @@ function wait_for_running_pod(name::AbstractString; timeout::Real)
     pod = nothing
 
     result = timedwait(timeout; pollint=1) do
-        pod = get_pod(name)
+        pod = @mock get_pod(name)
         pod["status"]["phase"] == "Running"
     end
 

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -117,6 +117,22 @@ end
         delete_pod(name_a, wait=false)
         delete_pod(name_b, wait=false)
     end
+
+    @testset "wait_for_running_pod" begin
+        manifest = deepcopy(pod_control_manifest)
+
+        prefix = "test-pod-control-wait-"
+        delete!(manifest["metadata"], "name")
+        manifest["metadata"]["generateName"] = prefix
+
+        name = create_pod(manifest)
+
+        @test_throws K8sClusterManagers.TimeoutException wait_for_running_pod(name; timeout=1)
+        pod = wait_for_running_pod(name; timeout=30)
+        @test pod["status"]["phase"] == "Running"
+
+        delete_pod(name, wait=false)
+    end
 end
 
 let job_name = "test-success"

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -55,6 +55,7 @@ end
         # call `create_pod` multiple times. However, we do want to avoid conflicts with previous
         # `Pkg.test` executions.
         name = "test-pod-control-named-" * randsuffix()
+        delete!(manifest["metadata"], "generateName")
         manifest["metadata"]["name"] = name
 
         @test_throws KubeError get_pod(name)
@@ -104,7 +105,6 @@ end
         manifest = deepcopy(pod_control_manifest)
 
         prefix = "test-pod-control-generate-name-"
-        delete!(manifest["metadata"], "name")
         manifest["metadata"]["generateName"] = prefix
 
         name_a = create_pod(manifest)
@@ -120,10 +120,7 @@ end
 
     @testset "wait_for_running_pod" begin
         manifest = deepcopy(pod_control_manifest)
-
-        prefix = "test-pod-control-wait-"
-        delete!(manifest["metadata"], "name")
-        manifest["metadata"]["generateName"] = prefix
+        manifest["metadata"]["generateName"] = "test-pod-control-wait-"
 
         name = create_pod(manifest)
 

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -117,19 +117,6 @@ end
         delete_pod(name_a, wait=false)
         delete_pod(name_b, wait=false)
     end
-
-    @testset "wait_for_running_pod" begin
-        manifest = deepcopy(pod_control_manifest)
-        manifest["metadata"]["generateName"] = "test-pod-control-wait-"
-
-        name = create_pod(manifest)
-
-        @test_throws K8sClusterManagers.TimeoutException wait_for_running_pod(name; timeout=1)
-        pod = wait_for_running_pod(name; timeout=30)
-        @test pod["status"]["phase"] == "Running"
-
-        delete_pod(name, wait=false)
-    end
 end
 
 let job_name = "test-success"

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -240,7 +240,10 @@ let job_name = "test-multi-addprocs"
         # Display details to assist in debugging the failure
         if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
             n = length(worker_pods)
-            worker_pairs = map((i, w) -> "worker $i/$n", enumerate(worker_pods))
+            worker_pairs = map(enumerate(worker_pods)) do (i, w)
+                "worker $i/$n" => w
+            end
+
             report(job_name, "manager" => manager_pod, worker_pairs...)
         end
     end

--- a/test/pod-control.yaml
+++ b/test/pod-control.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-control
+  generateName: test-pod-control-
 spec:
   restartPolicy: "Never"
   containers:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Distributed
 using K8sClusterManagers
 using K8sClusterManagers: DEFAULT_NAMESPACE, NAMESPACE_FILE
 using K8sClusterManagers: DEFAULT_WORKER_CPU, DEFAULT_WORKER_MEMORY
-using K8sClusterManagers: create_pod, delete_pod, get_pod
+using K8sClusterManagers: create_pod, delete_pod, get_pod, wait_for_running_pod
 using LibGit2: LibGit2
 using Mocking: Mocking, @patch, apply
 using Mustache: Mustache, render


### PR DESCRIPTION
Since we've removed Kuber.jl we no longer need to have special logic to handle API throttling exceptions. This overall has allowed the `Distributed.launch` method to be much cleaner.

Also, I fixed an issue with the reporting in the "test-multi-addprocs" test.