### PR TITLE
Rename `retry_seconds` to `pending_timeout`

### DIFF
--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -165,7 +165,7 @@ let job_name = "test-success"
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
-            addprocs(K8sClusterManager(1; configure, retry_seconds=60, cpu="0.5", memory="300Mi"))
+            addprocs(K8sClusterManager(1; configure, pending_timeout=60, cpu="0.5", memory="300Mi"))
 
             println("Num Processes: ", nprocs())
             for i in workers()
@@ -228,7 +228,7 @@ let job_name = "test-multi-addprocs"
                 return pod
             end
 
-            mgr = K8sClusterManager(1; configure, retry_seconds=60, cpu="0.5", memory="300Mi")
+            mgr = K8sClusterManager(1; configure, pending_timeout=60, cpu="0.5", memory="300Mi")
             addprocs(mgr)
             addprocs(mgr)
 
@@ -297,7 +297,7 @@ let job_name = "test-interrupt"
                 return pod
             end
 
-            mgr = K8sClusterManager(1; configure, retry_seconds=60, cpu="0.5", memory="300Mi")
+            mgr = K8sClusterManager(1; configure, pending_timeout=60, cpu="0.5", memory="300Mi")
             pids = addprocs(mgr)
             interrupt(pids)
             """


### PR DESCRIPTION
The name `retry_seconds` hasn't made much sense since retries were removed in #47. In #50 I changed the waiting behaviour to only timeout while waiting for a pending pod so now is the time change the keyword name.