### PR TITLE
Report abnormal worker terminations

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Distributed
 using K8sClusterManagers
 using K8sClusterManagers: DEFAULT_NAMESPACE, NAMESPACE_FILE
 using K8sClusterManagers: DEFAULT_WORKER_CPU, DEFAULT_WORKER_MEMORY
-using K8sClusterManagers: create_pod, delete_pod, exec_pod, get_pod, label_pod,
+using K8sClusterManagers: create_pod, delete_pod, exec_pod, get_pod, label_pod, pod_status,
     wait_for_running_pod
 using LibGit2: LibGit2
 using Mocking: Mocking, @patch, apply


### PR DESCRIPTION
Fixes https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/15. If a worker fails for any reason we now will report the termination reason specified by Kubernetes. This should be useful for cluster users by providing them a basic reason as to why their worker was terminated. Specifically this feature was added to inform users of workers being terminated due to running into memory limits (OOM).