### PR TITLE
Redirect worker output via `kubectl logs -f`

### DIFF
--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -1,7 +1,8 @@
 module K8sClusterManagers
 
 using DataStructures: DefaultOrderedDict, OrderedDict
-using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie
+using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie,
+    redirect_worker_output
 using JSON: JSON
 using Mocking: Mocking, @mock
 using kubectl_jll

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -1,8 +1,7 @@
 module K8sClusterManagers
 
 using DataStructures: DefaultOrderedDict, OrderedDict
-using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie,
-    redirect_worker_output
+using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie
 using JSON: JSON
 using Mocking: Mocking, @mock
 using kubectl_jll

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -1,10 +1,6 @@
 const DEFAULT_WORKER_CPU = 1
 const DEFAULT_WORKER_MEMORY = "4Gi"
 
-# Port number listened to by workers. The port number was randomly chosen from the ephemeral
-# port range: 49152-65535.
-const WORKER_PORT = 51400
-
 # Notifies tasks that the abnormal worker deregistration warning has been emitted
 const DEREGISTER_ALERT = Condition()
 
@@ -91,9 +87,7 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
     exename = params[:exename]
     exeflags = params[:exeflags]
 
-    # Note: We currently use the same port number for all workers but this isn't strictly
-    # required.
-    cmd = `$exename $exeflags --worker=$(cluster_cookie()) --bind-to=0:$WORKER_PORT`
+    cmd = `$exename $exeflags --worker=$(cluster_cookie())`
 
     worker_manifest = @static if VERSION >= v"1.5"
         worker_pod_spec(manager; cmd)
@@ -115,15 +109,16 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
                 rethrow()
             end
 
-            # Wait a few seconds to allow the worker to start listening to connections at
-            # expected port. If we don't wait long enough we will see a "connection refused"
-            # error (https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/46)
             @info "$pod_name is up"
-            sleep(4)
+
+            # Redirect any stdout/stderr from the worker to be displayed on the manager.
+            # Note: `start_worker` (via `--worker`) automatically redirects stderr to stdout
+            p = kubectl() do exe
+                open(detach(`$exe logs -f pod/$pod_name`), "r+")
+            end
 
             config = WorkerConfig()
-            config.host = pod["status"]["podIP"]
-            config.port = WORKER_PORT
+            config.io = p.out
             config.userdata = (; pod_name=pod_name)
 
             push!(launched, config)
@@ -139,16 +134,6 @@ function Distributed.manage(manager::K8sClusterManager, id::Integer, config::Wor
         # Note: Labelling the pod with the worker ID is only a nice-to-have. We may want to
         # make this fail gracefully if "patch" access is unavailable.
         label_pod(pod_name, "worker-id" => id)
-
-        # Redirect any stdout/stderr from the worker to be displayed on the manager. Note:
-        # The `start_worker` call via `--worker` automatically redirects stderr to stdout.
-        p = kubectl() do exe
-            open(detach(`$exe logs -f pod/$pod_name`), "r+")
-        end
-        readline(p.out)  # Ignore initial output: "julia_worker:<port>#<ip>"
-
-        config.io = p.out
-        redirect_worker_output(id, config.io)
 
     elseif op === :interrupt
         os_pid = config.ospid

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -29,6 +29,9 @@ const TEST_IMAGE = get(ENV, "K8S_CLUSTER_MANAGERS_TEST_IMAGE", "k8s-cluster-mana
 
 const POD_NAME_REGEX = r"Worker pod (?<worker_id>\d+): (?<pod_name>[a-z0-9.-]+)"
 
+# Note: Regex should be generic enough to capture any stray output from the workers
+const POD_OUTPUT_REGEX = r"From worker (?<worker_id>\d+):\s+(?<output>.*?)\r?\n"
+
 # As a convenience we'll automatically build the Docker image when a user uses `Pkg.test()`.
 # If the environmental variable is set we expect the Docker image has already been built.
 if !haskey(ENV, "K8S_CLUSTER_MANAGERS_TEST_IMAGE")
@@ -165,12 +168,17 @@ let job_name = "test-success"
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
-            addprocs(K8sClusterManager(1; configure, pending_timeout=60, cpu="0.5", memory="300Mi"))
+            pids = addprocs(K8sClusterManager(1; configure, pending_timeout=60, cpu="0.5", memory="300Mi"))
 
             println("Num Processes: ", nprocs())
             for i in workers()
                 # Return the name of the pod via HOSTNAME
                 println("Worker pod \$i: ", remotecall_fetch(() -> ENV["HOSTNAME"], i))
+            end
+
+            # Ensure that stdout/stderr on the worker is displayed on the manager
+            @everywhere pids begin
+                println(ENV["HOSTNAME"])
             end
             """
 
@@ -191,7 +199,8 @@ let job_name = "test-success"
         worker_pod = first(pod_names("manager" => manager_pod))
 
         manager_log = pod_logs(manager_pod)
-        matches = collect(eachmatch(POD_NAME_REGEX, manager_log))
+        call_matches = collect(eachmatch(POD_NAME_REGEX, manager_log))
+        output_matches = collect(eachmatch(POD_OUTPUT_REGEX, manager_log))
 
         test_results = [
             @test get_job(job_name, jsonpath="{.status..type}") == "Complete"
@@ -202,9 +211,13 @@ let job_name = "test-success"
             @test pod_phase(manager_pod) == "Succeeded"
             @test pod_phase(worker_pod) == "Succeeded"
 
-            @test length(matches) == 1
-            @test matches[1][:worker_id] == "2"
-            @test matches[1][:pod_name] == worker_pod
+            @test length(call_matches) == 1
+            @test call_matches[1][:worker_id] == "2"
+            @test call_matches[1][:pod_name] == worker_pod
+
+            @test length(output_matches) == 1
+            @test output_matches[1][:worker_id] == "2"
+            @test output_matches[1][:output] == worker_pod
 
             # Ensure there are no unexpected error messages in the log
             @test !occursin(r"\bError\b"i, manager_log)
@@ -321,7 +334,7 @@ let job_name = "test-interrupt"
             @test pod_phase(worker_pod) == "Failed"
 
             # Ensure there are no unexpected error messages in the log
-            @test !occursin(r"\bError\b"i, manager_log)
+            @test length(collect(eachmatch(r"\bError\b"i, manager_log))) == 1
         ]
 
         # Display details to assist in debugging the failure

--- a/test/job.template.yaml
+++ b/test/job.template.yaml
@@ -10,6 +10,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
 
 ---
 # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/


### PR DESCRIPTION
Addresses: https://github.com/beacon-biosignals/K8sClusterManagers.jl/issues/56