### PR TITLE
Redirect worker output via `kubectl attach`

### DIFF
--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -1,7 +1,7 @@
 module K8sClusterManagers
 
 using DataStructures: DefaultOrderedDict, OrderedDict
-using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie
+using Distributed: Distributed, ClusterManager, WorkerConfig, write_cookie
 using JSON: JSON
 using Mocking: Mocking, @mock
 using kubectl_jll

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -219,6 +219,7 @@ function worker_pod_spec!(pod::AbstractDict;
         rdict("name" => "worker",
               "image" => image,
               "command" => collect(cmd),
+              "stdin" => true,
               "resources" => rdict("requests" => rdict("cpu" => cpu,
                                                        "memory" => memory),
                                    "limits"   => rdict("cpu" => cpu,

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -204,7 +204,6 @@ let job_name = "test-success"
         call_matches = collect(eachmatch(POD_NAME_REGEX, manager_log))
         output_matches = collect(eachmatch(POD_OUTPUT_REGEX, manager_log))
 
-
         test_results = [
             @test get_job(job_name, jsonpath="{.status..type}") == "Complete"
 

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -29,6 +29,11 @@ const TEST_IMAGE = get(ENV, "K8S_CLUSTER_MANAGERS_TEST_IMAGE", "k8s-cluster-mana
 
 const POD_NAME_REGEX = r"Worker pod (?<worker_id>\d+): (?<pod_name>[a-z0-9.-]+)"
 
+# Note: Regex should be generic enough to capture any stray output from the workers
+const POD_OUTPUT_REGEX = r"From worker (?<worker_id>\d+):\s+(?<output>.*?)\r?\n"
+
+const PROMPT_HINT = "If you don't see a command prompt, try pressing enter."
+
 # As a convenience we'll automatically build the Docker image when a user uses `Pkg.test()`.
 # If the environmental variable is set we expect the Docker image has already been built.
 if !haskey(ENV, "K8S_CLUSTER_MANAGERS_TEST_IMAGE")
@@ -165,12 +170,17 @@ let job_name = "test-success"
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
-            addprocs(K8sClusterManager(1; configure, pending_timeout=60, cpu="0.5", memory="300Mi"))
+            pids = addprocs(K8sClusterManager(1; configure, pending_timeout=60, cpu="0.5", memory="300Mi"))
 
             println("Num Processes: ", nprocs())
             for i in workers()
                 # Return the name of the pod via HOSTNAME
                 println("Worker pod \$i: ", remotecall_fetch(() -> ENV["HOSTNAME"], i))
+            end
+
+            # Ensure that stdout/stderr on the worker is displayed on the manager
+            @everywhere pids begin
+                println(ENV["HOSTNAME"])
             end
             """
 
@@ -191,7 +201,9 @@ let job_name = "test-success"
         worker_pod = first(pod_names("manager" => manager_pod))
 
         manager_log = pod_logs(manager_pod)
-        matches = collect(eachmatch(POD_NAME_REGEX, manager_log))
+        call_matches = collect(eachmatch(POD_NAME_REGEX, manager_log))
+        output_matches = collect(eachmatch(POD_OUTPUT_REGEX, manager_log))
+
 
         test_results = [
             @test get_job(job_name, jsonpath="{.status..type}") == "Complete"
@@ -202,9 +214,16 @@ let job_name = "test-success"
             @test pod_phase(manager_pod) == "Succeeded"
             @test pod_phase(worker_pod) == "Succeeded"
 
-            @test length(matches) == 1
-            @test matches[1][:worker_id] == "2"
-            @test matches[1][:pod_name] == worker_pod
+            @test length(call_matches) == 1
+            @test call_matches[1][:worker_id] == "2"
+            @test call_matches[1][:pod_name] == worker_pod
+
+            @test length(output_matches) == 1
+            @test output_matches[1][:worker_id] == "2"
+            @test output_matches[1][:output] == worker_pod
+
+            # `kubectl attach` reports this warning
+            @test_broken !occursin(PROMPT_HINT, manager_log)
 
             # Ensure there are no unexpected error messages in the log
             @test !occursin(r"\bError\b"i, manager_log)
@@ -321,7 +340,7 @@ let job_name = "test-interrupt"
             @test pod_phase(worker_pod) == "Failed"
 
             # Ensure there are no unexpected error messages in the log
-            @test !occursin(r"\bError\b"i, manager_log)
+            @test length(collect(eachmatch(r"\bError\b"i, manager_log))) == 1
         ]
 
         # Display details to assist in debugging the failure

--- a/test/job.template.yaml
+++ b/test/job.template.yaml
@@ -10,6 +10,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods/attach"]
+  verbs: ["create"]
 
 ---
 # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -103,7 +103,7 @@ end
     @test length(pod["spec"]["containers"]) == 1
 
     worker = pod["spec"]["containers"][1]
-    @test keys(worker) == Set(["name", "image", "command", "resources"])
+    @test keys(worker) == Set(["name", "image", "command", "resources", "stdin"])
     @test worker["name"] == "worker"
     @test worker["image"] == "julia"
     @test worker["command"] == ["julia"]
@@ -111,6 +111,7 @@ end
     @test worker["resources"]["requests"]["memory"] == DEFAULT_WORKER_MEMORY
     @test worker["resources"]["limits"]["cpu"] == DEFAULT_WORKER_CPU
     @test worker["resources"]["limits"]["memory"] == DEFAULT_WORKER_MEMORY
+    @test worker["stdin"] == true
 end
 
 @testset "isk8s" begin


### PR DESCRIPTION
Alternative fix for #56 which currently is *non-functional*. The main issue seems to be that I can't seem to get stdin/stdout to work correctly with `kubectl attach`. There is one commit on this branch that works due but it only uses stdout and requires us to slow the worker down such that the output of the worker IP/port can be captured by the manager.