### PR TITLE
Update Documenter to 0.26

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 K8sClusterManagers = "5aeab163-63d2-4171-9fbf-e22244d80acb"
 
 [compat]
-Documenter = "~0.23"
+Documenter = "0.26"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter
 using K8sClusterManagers
 
 makedocs(modules=[K8sClusterManagers],
-         sitename="K8sClusterManagers",
+         sitename="K8sClusterManagers.jl",
          authors="Beacon Biosignals and other contributors",
          pages=["API Documentation" => "index.md"])
 


### PR DESCRIPTION
May fix #64. I noticed in the [Documenter CI job](https://github.com/beacon-biosignals/K8sClusterManagers.jl/runs/2470780970?check_suite_focus=true) that `GITHUB_TOKEN` wasn't listed which may be because we are using an old version of Documenter.jl:

```
┌ Info: Deployment criteria:
│ - ✔ ENV["TRAVIS_REPO_SLUG"]="" occurs in repo="github.com/beacon-biosignals/K8sClusterManagers.jl.git"
│ - ✘ ENV["TRAVIS_PULL_REQUEST"]="" is "false"
│ - ✔ ENV["TRAVIS_TAG"]="" is (i) empty or (ii) a valid VersionNumber
│ - ✘ ENV["TRAVIS_BRANCH"]="" matches devbranch="main" (if tag is empty)
│ - ✔ ENV["DOCUMENTER_KEY"] exists
│ - ✔ ENV["TRAVIS_EVENT_TYPE"]="" is not "cron"
└ Deploying: ✘