### PR TITLE
Add `az_node_selector` pod configuration function

### DIFF
--- a/src/pod.jl
+++ b/src/pod.jl
@@ -241,3 +241,19 @@ function isk8s()
     end
     return in_kubepod
 end
+
+
+"""
+    az_node_selector() -> Dict
+
+Add a nodeSelector to a new pod that will ensure that it runs in the same availability zone
+as the manager pod.
+"""
+function az_node_selector(pod)
+    pod_name = ENV["HOSTNAME"]
+    node_name = readchomp(`$(kubectl()) get pod $pod_name -o jsonpath='{.spec.nodeName}'`)
+    zone = readchomp(`$(kubectl()) get node $node_name -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}'`)
+    spec = get!(pod, "spec", Dict())
+    spec["nodeSelector"] = Dict("topology.kubernetes.io/zone" => zone)
+    return pod
+end


### PR DESCRIPTION
@vosscodes and I came up with this approach to making sure that jobs stay in the same AZ: you basically just need to make your `configure` function call the `az_node_selector` helper and that will ensure that worker nodes are all in the same AZ as the manager node.

It does require some permissions:

- "get" on pods in the namespace
- "get" on nodes at the cluster level

Tests and docs to come soon.