### PR TITLE
Updates to cluster tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,8 +54,17 @@ jobs:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
 
   cluster-test:
-    name: Cluster Test
+    name: Cluster Test - K8s ${{ matrix.k8s-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Support the latest versions of the supported releases: https://kubernetes.io/releases/
+        # These need to match the tags format: https://github.com/kubernetes/kubernetes/tags
+        k8s-version:
+          - "1.24.12"
+          - "1.25.8"
+          - "1.26"
     env:
       K8S_CLUSTER_TESTS: "true"
     steps:
@@ -89,9 +98,9 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.7.2
         with:
           # https://github.com/kubernetes/minikube/releases
-          minikube version: v1.22.0
-          # https://github.com/kubernetes/kubernetes/releases
-          kubernetes version: v1.21.4
+          minikube version: v1.29.0
+          # Needs to match the tags format: https://github.com/kubernetes/kubernetes/tags
+          kubernetes version: v${{ matrix.k8s-version }}
           driver: docker
           start args: --nodes=2 --cni=kindnet
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,12 +59,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Support the latest versions of the supported releases: https://kubernetes.io/releases/
-        # These need to match the tags format: https://github.com/kubernetes/kubernetes/tags
+        # Support the latest versions of the supported releases: https://kubernetes.io/releases/.
+        # These must be full version numbers including the patch.
         k8s-version:
           - "1.24.12"
           - "1.25.8"
-          - "1.26"
+          - "1.26.3"
     env:
       K8S_CLUSTER_TESTS: "true"
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,17 +54,21 @@ jobs:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
 
   cluster-test:
-    name: Cluster Test - K8s ${{ matrix.k8s-version }}
+    name: Cluster Test - Julia ${{matrix.julia-version }} - K8s ${{ matrix.k8s-version }} - minikube ${{ matrix.minikube-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        julia-version:
+          - "1"
         # Support the latest versions of the supported releases: https://kubernetes.io/releases/.
         # These must be full version numbers including the patch.
         k8s-version:
           - "1.24.12"
           - "1.25.8"
           - "1.26.3"
+        minikube-version:
+          - "1.29.0"
     env:
       K8S_CLUSTER_TESTS: "true"
     steps:
@@ -73,7 +77,7 @@ jobs:
           fetch-depth: 0
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1"
+          version: ${{ matrix.julia-version }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
 
@@ -98,7 +102,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.7.2
         with:
           # https://github.com/kubernetes/minikube/releases
-          minikube version: v1.29.0
+          minikube version: v${{ matrix.minikube-version }}
           # Needs to match the tags format: https://github.com/kubernetes/kubernetes/tags
           kubernetes version: v${{ matrix.k8s-version }}
           driver: docker

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -229,6 +229,10 @@ let job_name = "test-success"
         # Display details to assist in debugging the failure
         if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
             report(job_name, "manager" => manager_pod, "worker" => worker_pod)
+        else
+            @info "Deleting job/pods for $job_name"
+            delete_job(job_name; wait=false)
+            delete_pod(worker_pod; wait=false)
         end
     end
 end
@@ -298,6 +302,10 @@ let job_name = "test-multi-addprocs"
             end
 
             report(job_name, "manager" => manager_pod, worker_pairs...)
+        else
+            @info "Deleting job/pods for $job_name"
+            delete_job(job_name; wait=false)
+            foreach(pod_name -> delete_pod(pod_name; wait=false), worker_pods)
         end
     end
 end
@@ -343,6 +351,10 @@ let job_name = "test-interrupt"
         # Display details to assist in debugging the failure
         if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
             report(job_name, "manager" => manager_pod, "worker" => worker_pod)
+        else
+            @info "Deleting job/pods for $job_name"
+            delete_job(job_name; wait=false)
+            delete_pod(worker_pod; wait=false)
         end
     end
 end
@@ -412,6 +424,10 @@ let job_name = "test-oom"
         # Display details to assist in debugging the failure
         if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
             report(job_name, "manager" => manager_pod, "worker" => worker_pod)
+        else
+            @info "Deleting job/pods for $job_name"
+            delete_job(job_name; wait=false)
+            delete_pod(worker_pod; wait=false)
         end
     end
 end
@@ -469,6 +485,9 @@ let job_name = "test-pending-timeout"
         # Display details to assist in debugging the failure
         if any(r -> !(r isa Test.Pass || r isa Test.Broken), test_results)
             report(job_name, "manager" => manager_pod)
+        else
+            @info "Deleting job/pods for $job_name"
+            delete_job(job_name; wait=false)
         end
     end
 end

--- a/test/job.template.yaml
+++ b/test/job.template.yaml
@@ -42,8 +42,10 @@ kind: Job
 metadata:
   name: {{{:job_name}}}
 spec:
-  # Clean up finished jobs
-  ttlSecondsAfterFinished: 10
+  # Avoid using `ttlSecondsAfterFinished` as this will cause failed jobs to be cleaned up
+  # which makes debugging failures harder. Instead we'll just manually delete the created
+  # resources.
+
   # Stop the job from creating a new pod when the container exits in error
   backoffLimit: 0
   template:

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -83,3 +83,30 @@ function report(job_name, pods::Pair...)
         end
     end
 end
+
+function minikube_docker_env()
+    env_vars = Pair{String,String}[]
+    open(`minikube docker-env`) do f
+        while !eof(f)
+            line = readline(f)
+
+            if startswith(line, "export")
+                line = replace(line, r"^export " => "")
+                key, value = split(line, '='; limit=2)
+                push!(env_vars, key => unquote(value))
+            end
+        end
+    end
+
+    return env_vars
+end
+
+isquoted(str::AbstractString) = startswith(str, '"') && endswith(str, '"')
+
+function unquote(str::AbstractString)
+    if isquoted(str)
+        return replace(SubString(str, 2, lastindex(str) - 1), "\\\"" => "\"")
+    else
+        throw(ArgumentError("Passed in string is not quoted"))
+    end
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -27,6 +27,15 @@ function wait_job(job_name; condition=!isempty, timeout=60)
     end
 end
 
+function delete_job(name::AbstractString; wait::Bool=true)
+    kubectl_cmd = `$(kubectl()) delete job/$name --wait=$wait`
+    err = IOBuffer()
+    run(pipeline(ignorestatus(kubectl_cmd), stdout=devnull, stderr=err))
+
+    err.size > 0 && throw(KubeError(err))
+    return nothing
+end
+
 pod_exists(pod_name) = success(`$(kubectl()) get pod/$pod_name`)
 
 # Will fail if called and the job is in state "Waiting"


### PR DESCRIPTION
When running the cluster integration tests I was seeing issues with errors such as resource "NotFound". This turned out to be that the job TTL was cleaning up resources before the tests validated the results. I've since switched to deleting the resources manually to avoid such a scenario. This also as the added benefit of removing resources immediately when tests pass.

Additionally, having users specify `eval $(minikube docker-env)` before running the tests is easy to miss so I added some code to do that for the user.