### PR TITLE
Add a common test label to created resources

### DIFF
--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -84,12 +84,14 @@ end
 
         pod = get_pod(name)
         @test pod["status"]["phase"] == "Running"
-        @test isempty(get(pod["metadata"], "labels", Dict()))
+        labels = get(pod["metadata"], "labels", Dict())
+        @test !("testset" in keys(labels))
 
         label_pod(name, "testset" => "pod-control")
 
         pod = get_pod(name)
-        @test get_pod(name)["metadata"]["labels"] == Dict("testset" => "pod-control")
+        labels = get(pod["metadata"], "labels", Dict())
+        @test ("testset" => "pod-control") in labels
 
         # Avoid deleting the pod if we've reached a unhandled phase. This allows for
         # investigation with `kubectl`.

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -165,8 +165,11 @@ let job_name = "test-success"
         code = """
             using Distributed, K8sClusterManagers
 
-            # Avoid trying to pull local-only image
             function configure(pod)
+                # Add a origin label for easy cleanup of test resources
+                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+
+                # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
@@ -241,8 +244,11 @@ let job_name = "test-multi-addprocs"
         code = """
             using Distributed, K8sClusterManagers
 
-            # Avoid trying to pull local-only image
             function configure(pod)
+                # Add a origin label for easy cleanup of test resources
+                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+
+                # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
@@ -314,8 +320,11 @@ let job_name = "test-interrupt"
         code = """
             using Distributed, K8sClusterManagers
 
-            # Avoid trying to pull local-only image
             function configure(pod)
+                # Add a origin label for easy cleanup of test resources
+                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+
+                # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
@@ -363,8 +372,11 @@ let job_name = "test-oom"
         code = """
             using Distributed, K8sClusterManagers
 
-            # Avoid trying to pull local-only image
             function configure(pod)
+                # Add a origin label for easy cleanup of test resources
+                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+
+                # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end
@@ -436,8 +448,11 @@ let job_name = "test-pending-timeout"
         code = """
             using Distributed, K8sClusterManagers
 
-            # Avoid trying to pull local-only image
             function configure(pod)
+                # Add a origin label for easy cleanup of test resources
+                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+
+                # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
                 return pod
             end

--- a/test/job.template.yaml
+++ b/test/job.template.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: julia-manager-role
+  labels:
+    origin: k8s-cluster-manager-tests
 rules:
 - apiGroups: [""]  # "" indicates the core API group
   resources: ["pods"]
@@ -20,6 +22,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: julia-manager-serviceaccount
+  labels:
+    origin: k8s-cluster-manager-tests
 automountServiceAccountToken: true
 
 ---
@@ -27,6 +31,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: julia-manager-role-binding
+  labels:
+    origin: k8s-cluster-manager-tests
 roleRef:
   kind: Role
   name: julia-manager-role
@@ -41,6 +47,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{{:job_name}}}
+  labels:
+    origin: k8s-cluster-manager-tests
 spec:
   # Avoid using `ttlSecondsAfterFinished` as this will cause failed jobs to be cleaned up
   # which makes debugging failures harder. Instead we'll just manually delete the created
@@ -50,6 +58,9 @@ spec:
   backoffLimit: 0
   template:
     # Note: Pods are automatically assigned the label `job-name` using the job's name
+    metadata:
+      labels:
+        origin: k8s-cluster-manager-tests
     spec:
       serviceAccountName: julia-manager-serviceaccount
       restartPolicy: Never

--- a/test/pod-control.yaml
+++ b/test/pod-control.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   generateName: test-pod-control-
+  labels:
+    origin: k8s-cluster-manager-tests
 spec:
   restartPolicy: "Never"
   containers:


### PR DESCRIPTION
When the cluster tests encounter failure we avoid deleting the resources which failed in order to facilitate investigations. Unfortunately, cleaning up after failures can be rather tedious so I decided to add this common label to all resources created by these tests to make it easy to delete all created K8s resources via:
```sh
kubectl delete pod,job,sa,role,rolebinding -l origin=k8s-cluster-manager-tests
```