### PR TITLE
Refactor `isk8s`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "K8sClusterManagers"
 uuid = "5aeab163-63d2-4171-9fbf-e22244d80acb"
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/pod.jl
+++ b/src/pod.jl
@@ -227,17 +227,6 @@ end
 Predicate for testing if the current process is running within a Kubernetes (K8s) pod.
 """
 function isk8s()
-    in_kubepod = false
-    @mock(isfile("/proc/self/cgroup")) || return in_kubepod
-    @mock open("/proc/self/cgroup") do fp
-        while !eof(fp)
-            line = chomp(readline(fp))
-            path_name = split(line, ':')[3]
-            if startswith(path_name, "/kubepods/")
-                in_kubepod = true
-                break
-            end
-        end
-    end
-    return in_kubepod
+    # https://kubernetes.io/docs/reference/kubectl/#in-cluster-authentication-and-namespace-overrides
+    return haskey(ENV, "KUBERNETES_SERVICE_HOST") && haskey(ENV, "KUBERNETES_SERVICE_PORT")
 end

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -114,28 +114,11 @@ end
 end
 
 @testset "isk8s" begin
-    pod_id = "pode773d78d-9f0d-4003-a6e8-9bef75b89298/" *
-             "b52d083fb1f5b45d998895ab758d10fa36b2a53f3bf3128d7cf1d6d36bc67bd6"
-    cgroup = """
-        11:devices:/kubepods/$pod_id
-        10:blkio:/kubepods/$pod_id
-        9:hugetlb:/kubepods/$pod_id
-        8:net_cls,net_prio:/kubepods/$pod_id
-        7:memory:/kubepods/$pod_id
-        6:cpuset:/kubepods/$pod_id
-        5:perf_event:/kubepods/$pod_id
-        4:cpu,cpuacct:/kubepods/$pod_id
-        3:println()ids:/kubepods/$pod_id
-        2:freezer:/kubepods/$pod_id
-        1:name=systemd:/kubepods/$pod_id
-        """
+    withenv("KUBERNETES_SERVICE_HOST" => nothing, "KUBERNETES_SERVICE_PORT" => nothing) do
+        @test !isk8s()
+    end
 
-    patches = [
-        @patch isfile(p) = p == "/proc/self/cgroup"
-        @patch open(f, p) = f(IOBuffer(cgroup))
-    ]
-
-    apply(patches) do
+    withenv("KUBERNETES_SERVICE_HOST" => "10.0.0.1", "KUBERNETES_SERVICE_PORT" => "443") do
         @test isk8s()
     end
 end


### PR DESCRIPTION
Noticed this `isk8s` function no longer works on the latest version of Kubernetes. I've refactored this function to work on modern versions and have added some in-cluster tests to ensure this isn't missed again if this functionality breaks again.