### PR TITLE
Use Codecov `after_n_builds`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,9 @@ coverage:
 comment:
   show_carryforward_flags: true
 
-# Use `carryforward: true` to avoid misreporting coverage due to slow running cluster tests
-flag_management:
-  default_rules:
-    carryforward: true
+# Wait until 2x Julia unit tests jobs and 3x Cluster Test jobs have completed before reporting
+# coverage. Avoids reporting coverage too early which would show a misleading drop in code
+# coverage.
+# https://docs.codecov.com/docs/notifications#preventing-notifications-until-after-n-builds
+comment:
+  after_n_builds: 5

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,15 @@
-# https://docs.codecov.io/docs/pull-request-comments
+coverage:
+  status:
+    project:
+      # Default is a misnomer and these settings are not used as a fallback
+      default:
+        target: 60%  # Overall project/repo coverage
+        only_pulls: true
+
 comment:
-  behavior: new
+  show_carryforward_flags: true
+
+# Use `carryforward: true` to avoid misreporting coverage due to slow running cluster tests
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
Trying to reduce noise from Codecov which always reports that coverage has dropped as our unit tests finish far earlier than our cluster tests.

e.g.
![Screenshot 2023-04-10 at 12 38 02](https://user-images.githubusercontent.com/1675958/230963740-becb949e-a204-4aa5-8160-73232184aaef.png)
