### PR TITLE
Use `gethostname` to determine pod name

### DIFF
--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -46,8 +46,8 @@ available.
   their creation. Defaults to `identity`.
 """
 function K8sClusterManager(np::Integer;
-                           namespace::String=current_namespace(),
-                           manager_pod_name::String=gethostname(),
+                           namespace::AbstractString=current_namespace(),
+                           manager_pod_name::AbstractString=gethostname(),
                            image=nothing,
                            cpu=DEFAULT_WORKER_CPU,
                            memory=DEFAULT_WORKER_MEMORY,

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -30,7 +30,7 @@ available.
 
 - `namespace`: the Kubernetes namespace to launch worker pods within. Defaults to
   `current_namespace()`.
-- `manager_pod_name`: the name of the manager pod. Defaults to `ENV["HOSTNAME"]` which is
+- `manager_pod_name`: the name of the manager pod. Defaults to `gethostname()` which is
   the name of the pod when executed inside of a Kubernetes pod.
 - `image`: Docker image to use for the workers. Defaults to using the image of the Julia
   caller if running within a pod using a single container otherwise is a required argument.
@@ -47,7 +47,7 @@ available.
 """
 function K8sClusterManager(np::Integer;
                            namespace::String=current_namespace(),
-                           manager_pod_name::String=get(ENV, "HOSTNAME", "localhost"),
+                           manager_pod_name::String=gethostname(),
                            image=nothing,
                            cpu=DEFAULT_WORKER_CPU,
                            memory=DEFAULT_WORKER_MEMORY,

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -1,4 +1,15 @@
 @testset "K8sClusterManager" begin
+    @testset "basic" begin
+        mgr = K8sClusterManager(1; image="julia:1")
+        @test mgr.np == 1
+        @test mgr.pod_name == gethostname()
+        @test mgr.image == "julia:1"
+        @test mgr.cpu == string(K8sClusterManagers.DEFAULT_WORKER_CPU)
+        @test mgr.memory == K8sClusterManagers.DEFAULT_WORKER_MEMORY
+        @test mgr.pending_timeout == 180
+        @test mgr.configure === identity
+    end
+
     @testset "pods not found" begin
         try
             K8sClusterManager(1)


### PR DESCRIPTION
The `HOSTNAME` environmental variable does seem to always be set when running in a K8s pod but other environments should use `gethostname` to determine the hostname.