### PR TITLE
Refactor common test resource labels

### DIFF
--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -29,8 +29,8 @@ const TEST_IMAGE = get(ENV, "K8S_CLUSTER_MANAGERS_TEST_IMAGE", "k8s-cluster-mana
 
 # Add a labels for easy cleanup of test resources. Any changes to these common labels also
 # needs to occur in the YAML files included in the test directory
-# e.g. `kubectl delete pod,job,sa,role,rolebinding -l k8s-cluster-managers-tests=true`
-const COMMON_LABELS = ("k8s-cluster-managers-tests" => "true",)
+# e.g. `kubectl delete pod,job,sa,role,rolebinding -l package-test=K8sClusterManagers.jl`
+const COMMON_LABELS = ("package-test" => "K8sClusterManagers.jl",)
 
 const POD_NAME_REGEX = r"Worker pod (?<worker_id>\d+): (?<pod_name>[a-z0-9.-]+)"
 

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -27,6 +27,11 @@ end
 const JOB_TEMPLATE = Mustache.load(joinpath(@__DIR__, "job.template.yaml"))
 const TEST_IMAGE = get(ENV, "K8S_CLUSTER_MANAGERS_TEST_IMAGE", "k8s-cluster-managers:$TAG")
 
+# Add a labels for easy cleanup of test resources. Any changes to these common labels also
+# needs to occur in the YAML files included in the test directory
+# e.g. `kubectl delete pod,job,sa,role,rolebinding -l k8s-cluster-managers-tests=true`
+const COMMON_LABELS = ("k8s-cluster-managers-tests" => "true",)
+
 const POD_NAME_REGEX = r"Worker pod (?<worker_id>\d+): (?<pod_name>[a-z0-9.-]+)"
 
 # Note: Regex should be generic enough to capture any stray output from the workers
@@ -212,8 +217,7 @@ let job_name = "test-success"
             using Distributed, K8sClusterManagers
 
             function configure(pod)
-                # Add a origin label for easy cleanup of test resources
-                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+                push!(pod["metadata"]["labels"], "test" => "$job_name", $COMMON_LABELS...)
 
                 # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
@@ -291,8 +295,7 @@ let job_name = "test-multi-addprocs"
             using Distributed, K8sClusterManagers
 
             function configure(pod)
-                # Add a origin label for easy cleanup of test resources
-                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+                push!(pod["metadata"]["labels"], "test" => "$job_name", $COMMON_LABELS...)
 
                 # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
@@ -367,8 +370,7 @@ let job_name = "test-interrupt"
             using Distributed, K8sClusterManagers
 
             function configure(pod)
-                # Add a origin label for easy cleanup of test resources
-                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+                push!(pod["metadata"]["labels"], "test" => "$job_name", $COMMON_LABELS...)
 
                 # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
@@ -419,8 +421,7 @@ let job_name = "test-oom"
             using Distributed, K8sClusterManagers
 
             function configure(pod)
-                # Add a origin label for easy cleanup of test resources
-                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+                push!(pod["metadata"]["labels"], "test" => "$job_name", $COMMON_LABELS...)
 
                 # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"
@@ -495,8 +496,7 @@ let job_name = "test-pending-timeout"
             using Distributed, K8sClusterManagers
 
             function configure(pod)
-                # Add a origin label for easy cleanup of test resources
-                push!(pod["metadata"]["labels"], "origin" => "k8s-cluster-manager-tests")
+                push!(pod["metadata"]["labels"], "test" => "$job_name", $COMMON_LABELS...)
 
                 # Avoid trying to pull local-only image
                 pod["spec"]["containers"][1]["imagePullPolicy"] = "Never"

--- a/test/job.template.yaml
+++ b/test/job.template.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: julia-manager-role
   labels:
-    origin: k8s-cluster-manager-tests
+    k8s-cluster-managers-tests: "true"
 rules:
 - apiGroups: [""]  # "" indicates the core API group
   resources: ["pods"]
@@ -23,7 +23,7 @@ kind: ServiceAccount
 metadata:
   name: julia-manager-serviceaccount
   labels:
-    origin: k8s-cluster-manager-tests
+    k8s-cluster-managers-tests: "true"
 automountServiceAccountToken: true
 
 ---
@@ -32,7 +32,7 @@ kind: RoleBinding
 metadata:
   name: julia-manager-role-binding
   labels:
-    origin: k8s-cluster-manager-tests
+    k8s-cluster-managers-tests: "true"
 roleRef:
   kind: Role
   name: julia-manager-role
@@ -48,7 +48,7 @@ kind: Job
 metadata:
   name: {{{:job_name}}}
   labels:
-    origin: k8s-cluster-manager-tests
+    k8s-cluster-managers-tests: "true"
 spec:
   # Avoid using `ttlSecondsAfterFinished` as this will cause failed jobs to be cleaned up
   # which makes debugging failures harder. Instead we'll just manually delete the created
@@ -60,7 +60,7 @@ spec:
     # Note: Pods are automatically assigned the label `job-name` using the job's name
     metadata:
       labels:
-        origin: k8s-cluster-manager-tests
+        k8s-cluster-managers-tests: "true"
     spec:
       serviceAccountName: julia-manager-serviceaccount
       restartPolicy: Never

--- a/test/job.template.yaml
+++ b/test/job.template.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: julia-manager-role
   labels:
-    k8s-cluster-managers-tests: "true"
+    package-test: K8sClusterManagers.jl
 rules:
 - apiGroups: [""]  # "" indicates the core API group
   resources: ["pods"]
@@ -23,7 +23,7 @@ kind: ServiceAccount
 metadata:
   name: julia-manager-serviceaccount
   labels:
-    k8s-cluster-managers-tests: "true"
+    package-test: K8sClusterManagers.jl
 automountServiceAccountToken: true
 
 ---
@@ -32,7 +32,7 @@ kind: RoleBinding
 metadata:
   name: julia-manager-role-binding
   labels:
-    k8s-cluster-managers-tests: "true"
+    package-test: K8sClusterManagers.jl
 roleRef:
   kind: Role
   name: julia-manager-role
@@ -48,7 +48,7 @@ kind: Job
 metadata:
   name: {{{:job_name}}}
   labels:
-    k8s-cluster-managers-tests: "true"
+    package-test: K8sClusterManagers.jl
 spec:
   # Avoid using `ttlSecondsAfterFinished` as this will cause failed jobs to be cleaned up
   # which makes debugging failures harder. Instead we'll just manually delete the created
@@ -60,7 +60,7 @@ spec:
     # Note: Pods are automatically assigned the label `job-name` using the job's name
     metadata:
       labels:
-        k8s-cluster-managers-tests: "true"
+        package-test: K8sClusterManagers.jl
     spec:
       serviceAccountName: julia-manager-serviceaccount
       restartPolicy: Never

--- a/test/pod-control.yaml
+++ b/test/pod-control.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   generateName: test-pod-control-
   labels:
-    origin: k8s-cluster-manager-tests
+    k8s-cluster-managers-tests: "true"
 spec:
   restartPolicy: "Never"
   containers:

--- a/test/pod-control.yaml
+++ b/test/pod-control.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   generateName: test-pod-control-
   labels:
-    k8s-cluster-managers-tests: "true"
+    package-test: K8sClusterManagers.jl
 spec:
   restartPolicy: "Never"
   containers:


### PR DESCRIPTION
Follow up to #98. Makes it easier to update the common test labels in Julia code and also changes the label used (the "origin" label was attempting to be too generic).