### PR TITLE
Separate keywords `worker_prefix` and `manager_pod_name`

### DIFF
--- a/src/pod.jl
+++ b/src/pod.jl
@@ -191,16 +191,16 @@ function worker_pod_spec(pod::AbstractDict=POD_TEMPLATE; kwargs...)
 end
 
 function worker_pod_spec!(pod::AbstractDict;
-                          manager_name::AbstractString,
+                          worker_prefix::AbstractString,
                           image::AbstractString,
                           cmd::Cmd,
                           cpu=DEFAULT_WORKER_CPU,
                           memory=DEFAULT_WORKER_MEMORY,
                           service_account_name=nothing)
-    pod["metadata"]["generateName"] = "$(manager_name)-worker-"
+    pod["metadata"]["generateName"] = "$(worker_prefix)-"
 
-    # Set a label with the manager name to support easy termination of all workers
-    pod["metadata"]["labels"]["manager"] = manager_name
+    # Set a label with the `worker_prefix` to support easy termination of all workers
+    pod["metadata"]["labels"]["worker-prefix"] = worker_prefix
 
     worker_container =
         rdict("name" => "worker",

--- a/test/native_driver.jl
+++ b/test/native_driver.jl
@@ -2,12 +2,27 @@
     @testset "basic" begin
         mgr = K8sClusterManager(1; image="julia:1")
         @test mgr.np == 1
-        @test mgr.pod_name == gethostname()
+        @test mgr.worker_prefix == "$(gethostname())-worker"
         @test mgr.image == "julia:1"
         @test mgr.cpu == string(K8sClusterManagers.DEFAULT_WORKER_CPU)
         @test mgr.memory == K8sClusterManagers.DEFAULT_WORKER_MEMORY
         @test mgr.pending_timeout == 180
         @test mgr.configure === identity
+    end
+
+    @testset "worker_prefix" begin
+        kwargs = (; image="julia:1")
+        mgr = K8sClusterManager(1; kwargs...)
+        @test mgr.worker_prefix == "$(gethostname())-worker"
+
+        mgr = K8sClusterManager(1; worker_prefix="wkr-group", kwargs...)
+        @test mgr.worker_prefix == "wkr-group"
+
+        mgr = K8sClusterManager(1; manager_pod_name="pod", kwargs...)
+        @test mgr.worker_prefix == "pod-worker"
+
+        mgr = K8sClusterManager(1; worker_prefix="wkr-group", manager_pod_name="pod", kwargs...)
+        @test mgr.worker_prefix == "wkr-group"
     end
 
     @testset "pods not found" begin

--- a/test/pod.jl
+++ b/test/pod.jl
@@ -87,7 +87,7 @@ end
 end
 
 @testset "worker_pod_spec" begin
-    kwargs = (; manager_name="test", image="julia", cmd=`julia`)
+    kwargs = (; worker_prefix="test-wkr", image="julia", cmd=`julia`)
     pod = K8sClusterManagers.worker_pod_spec(; kwargs...)
 
     @test keys(pod) == Set(["apiVersion", "kind", "metadata", "spec"])
@@ -95,9 +95,9 @@ end
     @test pod["kind"] == "Pod"
 
     @test keys(pod["metadata"]) == Set(["generateName", "labels"])
-    @test pod["metadata"]["generateName"] == "test-worker-"
-    @test keys(pod["metadata"]["labels"]) == Set(["manager"])
-    @test pod["metadata"]["labels"]["manager"] == "test"
+    @test pod["metadata"]["generateName"] == "test-wkr-"
+    @test keys(pod["metadata"]["labels"]) == Set(["worker-prefix"])
+    @test pod["metadata"]["labels"]["worker-prefix"] == "test-wkr"
 
     @test pod["spec"]["restartPolicy"] == "Never"
     @test length(pod["spec"]["containers"]) == 1


### PR DESCRIPTION
Allows end users to customize the prefix assigned to worker names while still begin able to look up the image of a manager pod. I did like how workers were assigned the name of their manager via labels in the old code but in the new world where we have managers which are external to the cluster this seems more sensible.