### PR TITLE
Support managers external to K8s clusters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Mocking = "0.7"
 Mustache = "1"
 YAML = "0.4.6"
 julia = "1.6"
-kubectl_jll = "1.20.0"
+kubectl_jll = "1.20"
 
 [extras]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "K8sClusterManagers"
 uuid = "5aeab163-63d2-4171-9fbf-e22244d80acb"
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "5aeab163-63d2-4171-9fbf-e22244d80acb"
 version = "0.1.4"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -10,6 +11,7 @@ Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 kubectl_jll = "ed23c2a5-89c4-5d52-b0ca-9d53aadf8c45"
 
 [compat]
+Compat = "3.29, 4"
 DataStructures = "0.18"
 JSON = "0.21"
 Mocking = "0.7"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Now in this Julia REPL session, you can do add two workers via:
 ```julia
 julia> using Pkg; Pkg.add("K8sClusterManagers")
 
-julia> using K8sClusterManagers
+julia> using K8sClusterManagers, Distributed
 
 julia> addprocs(K8sClusterManager(2))
 ```

--- a/README.md
+++ b/README.md
@@ -7,22 +7,41 @@
 
 A Julia cluster manager for provisioning workers in a Kubernetes (K8s) cluster.
 
-Pairs well with [`julia_pod`](https://github.com/beacon-biosignals/julia_pod) for interactive Julia development within a K8s pod. 
-
 ## K8sClusterManager
 
-The `K8sClusterManager` is intended to be used from a Pod running inside a Kubernetes
-cluster.
+The `K8sClusterManager` can be used both inside and outside of a Kubernetes cluster.
+To get started you'll need access to a K8s cluster and have configured your machine with
+access to the cluster. If you're new to K8s we recommend you use use [minikube](https://minikube.sigs.k8s.io)
+to quickly setup a local Kubernetes cluster.
 
-Assuming you have `kubectl` installed locally and configured to connect to a cluster, you
-can easily create an interactive Julia REPL session running from within the cluster by
-executing:
+### Running outside K8s
+
+A distributed Julia cluster where the manager runs outside of K8s while the workers run in
+the cluster can quickly be created via:
+
+```julia
+julia> using K8sClusterManagers, Distributed
+
+julia> addprocs(K8sClusterManager(2))
+```
+
+When using the manager outside of Kubernetes cluster the manager will connect to workers
+within the cluster using port-forwarding. Performance between the manager and workers will
+be impacted by the network connection between the manager and the cluster.
+
+### Running inside K8s
+
+A Julia process running within a K8s cluster can also be used as a Julia distributed
+manager.
+
+To see this in action we'll create an interactive Julia REPL session running within the
+cluster by executing:
 
 ```sh
 kubectl run -it example-manager-pod --image julia:1
 ```
 
-Or equivalently, using a K8s manifest named `example-manager-pod.yaml` containing:
+or equivalently, using a K8s manifest named `example-manager-pod.yaml` containing:
 
 ```yaml
 apiVersion: v1

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,16 +1,15 @@
 Examples
 ========
 
-The [`K8sClusterManager`](@ref) is intended to be used inside a [Pod](https://kubernetes.io/docs/concepts/workloads/pods/)
-running on a Kubernetes cluster.
+The `K8sClusterManager` can be used both inside and outside of a Kubernetes cluster.
 
 ## Launching an interactive session
 
 The following manifest will create a Kubernetes [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
-named "interactive-session". This Job will spawn a Pod (see `spec.template.spec`) which will
-run an interactive Julia session with the latest release of K8sClusterManagers.jl installed.
-Be sure to create the required [ServiceAccount and associated permissions](../patterns/#required-permissions)
-before proceeding.
+named "interactive-session". This Job will spawn a [Pod](https://kubernetes.io/docs/concepts/workloads/pods/)
+(see `spec.template.spec`) which will run an interactive Julia session with the latest
+release of K8sClusterManagers.jl installed. Be sure to create the required [ServiceAccount
+and associated permissions](../patterns/#required-permissions) before proceeding.
 
 ````@eval
 using Markdown
@@ -36,11 +35,12 @@ echo $manager_pod
 kubectl attach -it pod/${manager_pod?}
 ```
 
-### Launching workers
+## Launching workers
 
-Once you've attached to the interactive session you can use [`K8sClusterManager`](@ref) to
-spawn K8s workers. For our example we'll be using a small amount of CPU/Memory to ensure
-workers can be spawned even on clusters with limited resources:
+You can use [`K8sClusterManager`](@ref) to spawn workers within the K8s cluster. The cluster
+manager can be used both inside/outside of the K8s cluster. In the following example we'll
+be using a small amount of CPU/Memory to ensure workers can be spawned even on clusters with
+limited resources:
 
 ```julia
 julia> using Distributed, K8sClusterManagers
@@ -61,7 +61,7 @@ julia> pmap(x -> myid(), 1:nworkers())  # Each worker reports its worker ID
  2
 ```
 
-### Pending workers
+## Pending workers
 
 A worker created via `addprocs` may not necessarily be available right away, as K8s must
 schedule the worker's Pod to a Node before the corresponding Julia process can start.
@@ -74,7 +74,7 @@ the manager will continue with the subset of workers which have reported in and 
 workers that are stuck in the "Pending" phase.
 
 ```julia
-julia> addprocs(K8sClusterManager(1, memory="1Ei", pending_timeout=10))  # Request 1 exbibyte of memory
+julia> addprocs(K8sClusterManager(1, memory="1Pi", pending_timeout=10))  # Request 1 pebibyte of memory
 ┌ Warning: TimeoutException: timed out after waiting for worker interactive-session-d7jfb-worker-ffvnm to start for 10 seconds, with status:
 │ {
 │     "conditions": [
@@ -94,7 +94,7 @@ julia> addprocs(K8sClusterManager(1, memory="1Ei", pending_timeout=10))  # Reque
 Int64[]
 ```
 
-### Termination Reason
+## Termination Reason
 
 When Julia workers [exceed the specified memory limit](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/#exceed-a-container-s-memory-limit)
 the worker Pod will be automatically killed by Kubernetes (OOMKilled). In such a

--- a/src/K8sClusterManagers.jl
+++ b/src/K8sClusterManagers.jl
@@ -1,5 +1,6 @@
 module K8sClusterManagers
 
+using Compat: @something
 using DataStructures: DefaultOrderedDict, OrderedDict
 using Distributed: Distributed, ClusterManager, WorkerConfig, cluster_cookie
 using JSON: JSON

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -212,11 +212,11 @@ end
 # Stripped down and modified version of:
 # https://github.com/JuliaLang/julia/blob/844c20dd63870aa5b369b85038f0523d7d79308a/stdlib/Distributed/src/managers.jl#L567-L632
 function Distributed.connect(manager::K8sClusterManager, pid::Int, config::WorkerConfig)
-    if config.connect_at !== nothing
-        # this is a worker-to-worker setup call.
-        # return Distributed.connect_w2w(pid, config)
-        error("foo")
-    end
+    # Note: This method currently doesn't implement support for worker-to-worker
+    # connections and instead relies on the `Distributed.connect(::DefaultClusterManager, ...)`
+    # for this. If we did need to perform special logic for worker-to-worker connections
+    # we would need to modify how `init_worker` is called via `start_worker`:
+    # https://github.com/JuliaLang/julia/blob/f7554b5c9f0f580a9fcf5c7b8b9a83b678e2f48a/stdlib/Distributed/src/cluster.jl#L375-L378
 
     # master connecting to workers
     if config.io !== nothing

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -40,7 +40,7 @@ available.
   for each worker. Defaults to `$(repr(DEFAULT_WORKER_CPU))`,
 - `memory`: [Memory resource requested](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)
   for each worker in bytes. Requests may provide a unit suffix (e.g. "G" for Gigabytes and
-  "GiB" for Gibibytes). Defaults to `$(repr(DEFAULT_WORKER_MEMORY))`.
+  "Gi" for Gibibytes). Defaults to `$(repr(DEFAULT_WORKER_MEMORY))`.
 - `pending_timeout`: The maximum number of seconds to wait for a "Pending" worker pod to
   enter the "Running" phase. Once the timeout has been reached the manager will continue
   with the number of workers available (`<= np`). Defaults to `180` (3 minutes).

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -109,6 +109,9 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
         @async begin
             pod_name = create_pod(worker_manifest)
 
+            # TODO: Add notice about having to pull an image. On a slow internet connection
+            # this can make it appear that the cluster start is hung
+
             pod = try
                 wait_for_running_pod(pod_name; timeout=manager.pending_timeout)
             catch e

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -101,6 +101,10 @@ function Distributed.launch(manager::K8sClusterManager, params::Dict, launched::
     # Note: User-defined `configure` function may or may-not be mutating
     worker_manifest = manager.configure(worker_manifest)
 
+    # Trigger any TOTP requests before the async loop
+    # TODO: Verify this is working correctly
+    success(`$(kubectl()) get pods -o 'jsonpath={.items[*].metadata.null}'`)
+
     @sync for i in 1:manager.np
         @async begin
             pod_name = create_pod(worker_manifest)

--- a/src/native_driver.jl
+++ b/src/native_driver.jl
@@ -214,7 +214,8 @@ end
 function Distributed.connect(manager::K8sClusterManager, pid::Int, config::WorkerConfig)
     if config.connect_at !== nothing
         # this is a worker-to-worker setup call.
-        return Distributed.connect_w2w(pid, config)
+        # return Distributed.connect_w2w(pid, config)
+        error("foo")
     end
 
     # master connecting to workers

--- a/test/cluster.jl
+++ b/test/cluster.jl
@@ -230,7 +230,7 @@ let test_name = "test-k8s-external-manager"
         @test !isk8s()
 
         worker_ids = addprocs(K8sClusterManager(1; configure, worker_prefix, pending_timeout=60, cpu="0.5", memory="300Mi"))
-        @test nworkers() == 1
+        @test nprocs() == 2
 
         worker_id = only(worker_ids)
         worker_pod = remotecall_fetch(gethostname, worker_id)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -56,6 +56,12 @@ function pod_names(labels::Pair...; sort_by=nothing)
     return !isempty(output) ? split(output, '\n') : String[]
 end
 
+function pod_images(pod_name)
+    jsonpath = """{range .spec.containers[*]}{.image}{"\\n"}{end}"""
+    output = readchomp(`$(kubectl()) get pod/$pod_name -o jsonpath=$jsonpath`)
+    return split(output, '\n'; keepempty=false)
+end
+
 # Use the double-quoted flow scalar style to allow us to have a YAML string which includes
 # newlines without being aware of YAML indentation (block styles)
 #


### PR DESCRIPTION
Replaces #94. Adds support for having the Julia cluster manager running externally from the workers running inside a cluster while retaining support for in-cluster managers. 

Julia's Distributed package isn't well suited for the heterogeneous network connections we're using here so I was forced to extend the `Distributed.connect` function and modify it's behaviour for this particular cluster manager. In particular manager-to-worker connections need to use the special port-forwarded addresses while workers can continue to use intra cluster network connections. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204267974135853